### PR TITLE
Fix minor typos and incorrect setup description for example

### DIFF
--- a/src/main/asciidoc/api/http.adoc
+++ b/src/main/asciidoc/api/http.adoc
@@ -139,7 +139,7 @@ curl -X POST http://localhost:2480/api/v1/begin/school
      --user root:root
 ```
 
-Returns the Session Id in the response header, exampe:
+Returns the Session Id in the response header, example:
 
 `arcadedb-session-id: AS-ee056170-dc9b-4956-8d71-d7cfa01900d4`
 
@@ -296,7 +296,7 @@ curl -X POST http://localhost:2480/api/v1/drop/school
 [[HTTP-ExecuteQuery]]
 ===== Execute a query (GET)
 
-This command allows executing idempotent commands, like `SELECT` ad `MATCH`:
+This command allows executing idempotent commands, like `SELECT` and `MATCH`:
 
 URL Syntax 1: `/api/v1/query/{database}`
 
@@ -310,7 +310,7 @@ The payload, as a JSON, accepts the following parameters:
 - `command` the command to execute in encoded format
 - `params` (optional), is the map of parameters to pass to the query engine
 
-Example of insertion of a new Client by using parameters:
+Example of retrieving the class with name "English" by using parameters:
 
 ```
 curl -X POST http://localhost:2480/api/v1/command/company


### PR DESCRIPTION
I found a couple of minor typos and corrected them.

Additionally, in the example documentation for `query`, the setup description for the parameter-based query mentioned performing an update (a non-idempotent statement) but the example's contents were a select statement (which is idempotent).  I updated the setup description to reflect what the query was doing.