### PR TITLE
Fix unquoted params value in curl example

### DIFF
--- a/src/main/asciidoc/api/http.adoc
+++ b/src/main/asciidoc/api/http.adoc
@@ -102,7 +102,7 @@ Or better, using parameters with SQL:
 
 ```
 curl -X POST http://localhost:2480/api/v1/command/school
-     -d '{ "language": "sql", "command": "insert into Class set name = :name, location = :location", params: { "name": "English", "location": "3rd floor" }}'
+     -d '{ "language": "sql", "command": "insert into Class set name = :name, location = :location", "params": { "name": "English", "location": "3rd floor" }}'
      -H "Content-Type: application/json"
      --user root:root
 ```


### PR DESCRIPTION
In the `curl` example for using parameters with SQL, fix the JSON body that is provided in the example so that it quotes the `params` identifier.