### PR TITLE
Added comment to server-endpoint reference

### DIFF
--- a/src/main/asciidoc/api/http.adoc
+++ b/src/main/asciidoc/api/http.adoc
@@ -481,6 +481,9 @@ Returns the current HA configuration.
 
 URL Syntax: `/api/v1/server`
 
+If ArcadeDB runs distributed, it returns the cluster configuration, otherwise just `{}`,
+hence it can also be used to check if the server is ready.
+
 Example:
 
 [source,shell]


### PR DESCRIPTION
Added comment to `server` endpoint reference in HTTP/JSON Protocol / Reference (7.2.1), paraphrasing https://github.com/ArcadeData/arcadedb/issues/528#issuecomment-1255525603 .