### PR TITLE
Fix Linking issues #43 

### DIFF
--- a/src/main/asciidoc/api/chapter.adoc
+++ b/src/main/asciidoc/api/chapter.adoc
@@ -10,7 +10,7 @@ ArcadeDB supports multiple languages, so it's easier to use it coming from other
 |<<Java-API,JVM Embedded API>>
 |<<SQL,SQL>>
 |<<Gremlin-API,Apache Gremlin>>
-|<<_open-chyper,Cypher>>
+|<<Open-Cyper,Cypher>>
 |<<GraphQL,GraphQL>>
 |<<MongoDB-API,MongoDB Query>>
 |<<Redis-API,Redis>>

--- a/src/main/asciidoc/api/chapter.adoc
+++ b/src/main/asciidoc/api/chapter.adoc
@@ -10,7 +10,7 @@ ArcadeDB supports multiple languages, so it's easier to use it coming from other
 |<<Java-API,JVM Embedded API>>
 |<<SQL,SQL>>
 |<<Gremlin-API,Apache Gremlin>>
-|<<Open-Cyper,Cypher>>
+|<<Open-Cypher,Cypher>>
 |<<GraphQL,GraphQL>>
 |<<MongoDB-API,MongoDB Query>>
 |<<Redis-API,Redis>>

--- a/src/main/asciidoc/api/cypher.adoc
+++ b/src/main/asciidoc/api/cypher.adoc
@@ -1,3 +1,4 @@
+[[Open-Cypher]]
 === Open Cypher
 
 image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/api/cypher.adoc" float=right]

--- a/src/main/asciidoc/api/graphql.adoc
+++ b/src/main/asciidoc/api/graphql.adoc
@@ -1,3 +1,4 @@
+[[GraphQL]]
 === GraphQL
 
 image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/api/graphql.adoc" float=right]

--- a/src/main/asciidoc/api/graphql.adoc
+++ b/src/main/asciidoc/api/graphql.adoc
@@ -127,7 +127,7 @@ Syntax: `@sql( statement: <sql-statement> )`
 Executes a <<SQL,SQL>> query.
 The query can use parameters passed at invocation time.
 
-Example of definition of a query using <<_sql,SQL>> in GraphQL:
+Example of definition of a query using <<SQL,SQL>> in GraphQL:
 
 [source,graphql]
 ----
@@ -172,10 +172,10 @@ Applies to: `Query Field` and `Field Definition`
 
 Syntax: `@cypher( statement: <cypher-statement> )`
 
-Executes a <<_open-cypher,Cypher>> query.
+Executes a <<Open-Cypher,Cypher>> query.
 The query can use parameters passed at invocation time.
 
-Example of definition of a query using <<_open-cypher,Cypher>> in GraphQL:
+Example of definition of a query using <<Open-Cypher,Cypher>> in GraphQL:
 
 [source,graphql]
 ----

--- a/src/main/asciidoc/api/gremlin.adoc
+++ b/src/main/asciidoc/api/gremlin.adoc
@@ -105,4 +105,4 @@ For more information about Gremlin:
 - http://tinkerpop.apache.org/docs/current/tutorials/getting-started/[Getting Started with Gremlin]
 - http://tinkerpop.apache.org/docs/current/tutorials/the-gremlin-console/[The Gremlin Console]
 - http://tinkerpop.apache.org/docs/current/recipes/[Gremlin Recipes]
-- http://kelvinlawrence.net/book/Gremlin-Graph-Guide.html/[PRACTICAL GREMLIN: An Apache TinkerPop Tutorial]
+- https://kelvinlawrence.net/book/PracticalGremlin.html[PRACTICAL GREMLIN: An Apache TinkerPop Tutorial]

--- a/src/main/asciidoc/api/java-reference.adoc
+++ b/src/main/asciidoc/api/java-reference.adoc
@@ -1,5 +1,4 @@
-[discrete]
-== Java Reference
+=== Java Reference
 
 image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/api/java-reference.adoc" float=right]
 

--- a/src/main/asciidoc/api/java-schema.adoc
+++ b/src/main/asciidoc/api/java-schema.adoc
@@ -1,3 +1,5 @@
+
+
 ==== Schema
 
 image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/api/java-schema.adoc" float=right]

--- a/src/main/asciidoc/api/java-tutorial.adoc
+++ b/src/main/asciidoc/api/java-tutorial.adoc
@@ -249,7 +249,7 @@ You have basically three ways to do that (<<Java-API,Java API>>, <<SQL,SQL>>, ht
 |<<Java-API,JVM Embedded API>>
 |<<SQL,SQL>>
 |<<Gremlin-API,Apache Gremlin>>
-|<<_open-cypher,Cypher>>
+|<<Open-Cypher,Cypher>>
 
 |Speed|* * *|* *|* *|* *
 |Flexibility|* * *|*|* *|* *
@@ -397,14 +397,7 @@ Since ArcadeDB is 100% compliant with Gremlin 3.4.x, you can run this query agai
 g.V().has('name','Steve').has('lastName','Jobs').out('IsFriendOf');
 ----
 
-For more information about Apache Gremlin:
-
-- ArcadeDB <<Gremlin-API,Gremlin API>> support
-- http://tinkerpop.apache.org/gremlin.html[Introduction to Gremlin]
-- http://tinkerpop.apache.org/docs/current/tutorials/getting-started/[Getting Started with Gremlin]
-- http://tinkerpop.apache.org/docs/current/tutorials/the-gremlin-console/[The Gremlin Console]
-- http://tinkerpop.apache.org/docs/current/recipes/[Gremlin Recipes]
-- http://kelvinlawrence.net/book/Gremlin-Graph-Guide.html/[PRACTICAL GREMLIN: An Apache TinkerPop Tutorial]
+For more information about Apache Gremlin see: <<Gremlin-API,Gremlin API>> support
 
 ====== Traverse via Open Cypher
 
@@ -418,8 +411,5 @@ WHERE me.name = 'Steve' and me.lastName = 'Jobs'
 RETURN friend.name, friend.lastName
 ----
 
-For more information about Cypher:
+For more information about Cypher see: <<Open-Cypher,Cypher>> support
 
-- ArcadeDB <<_open-chyper,Cypher>> support
-- https://opencypher.org/[Open Cypher]
-- https://neo4j.com/docs/cypher-manual/current/[The Neo4j Cypher Manual]

--- a/src/main/asciidoc/api/mongo.adoc
+++ b/src/main/asciidoc/api/mongo.adoc
@@ -82,7 +82,7 @@ In this way you can use any MongoDB driver for any supported programming languag
 
 ArcadeDB Server supports a subset of the https://mongodb.com[MongoDB] protocol, like CRUD operations and queries.
 
-To start the MongoDB plugin, enlist it in the <<#_settings,`server.plugins`>> settings.
+To start the MongoDB plugin, enlist it in the <<#Settings,`server.plugins`>> settings.
 To specify multiple plugins, use the comma `,` as separator.
 
 Example to start ArcadeDB with the MongoDB Plugin:

--- a/src/main/asciidoc/api/postgres.adoc
+++ b/src/main/asciidoc/api/postgres.adoc
@@ -66,7 +66,7 @@ For the complete list, please check https://wiki.postgresql.org/wiki/List_of_dri
 === Execute multiple query languages
 
 By default the Postgres driver interpret all the commands as <<SQL,SQL>>.
-To use another supported language, like <<_open-cypher,Cypher>>, <<Gremlin-API,Gremlin>>, <<GraphQL,GraphQL>> or <<MongoDB-API,MongoDB>>, prefix the command with the language to use between curly brackets.
+To use another supported language, like <<Open-Cypher,Cypher>>, <<Gremlin-API,Gremlin>>, <<GraphQL,GraphQL>> or <<MongoDB-API,MongoDB>>, prefix the command with the language to use between curly brackets.
 
 Example to execute a query by using GraphQL:
 

--- a/src/main/asciidoc/api/redis.adoc
+++ b/src/main/asciidoc/api/redis.adoc
@@ -29,7 +29,7 @@ You can save and read any documents, vertices and edges from the underlying data
 [[Redis-Protocol]]
 ==== Installation
 
-To start the Redis plugin, enlist it in the <<#_settings,`server.plugins`>> settings.
+To start the Redis plugin, enlist it in the <<#Settings,`server.plugins`>> settings.
 To specify multiple plugins, use the comma `,` as separator.
 Example:
 
@@ -188,7 +188,7 @@ This is because JSON doesn't maintain the order of properties, but only of array
 
 - https://redis.io/commands/hdel[HDEL], to delete one or more records by a key, a composite key or record's id
 - https://redis.io/commands/hget[HGET], to retrieve a record by a key, a composite key or record's id
-- https://redis.io/commands/hget[HMGET], to retrieve multiple records by a key, a composite key or record's id
+- https://redis.io/commands/hmget[HMGET], to retrieve multiple records by a key, a composite key or record's id
 - https://redis.io/commands/hset[HSET], to create and update one or more records by a key, a composite key or record's id
 
 [discrete]

--- a/src/main/asciidoc/appendix/chapter.adoc
+++ b/src/main/asciidoc/appendix/chapter.adoc
@@ -1,4 +1,5 @@
-== Appendixes
+[[Appendix]]
+== Appendix
 
 include::datatypes.adoc[]
 

--- a/src/main/asciidoc/appendix/datatypes.adoc
+++ b/src/main/asciidoc/appendix/datatypes.adoc
@@ -25,7 +25,7 @@ The contained records have no <<RID,RID>> and are reachable only by navigating t
 |Embedded map|MAP|The Records are contained inside the owner as values of the entries, while the keys can only be Strings.
 The contained ords e no <<RID,RIDs>> and are reachable only by navigating the owner Record|`Map&lt;String, EmbeddedDocument&gt;`|0 - 41,000,000 items|`Collection&lt;? extends EmbeddedDocument&lt;?&gt;&gt;`, `String`
 |Link|LINK|Link to another Record.
-It's a common <<_-11-and-1n-referenced-relationships,one-to-one relationship>>|`RID`, `&lt;? extends Record&gt;`|1:-1 - 32767:2^63-1|String
+It's a common <<_11-and-n1-embedded-relationships,one-to-one relationship>>|`RID`, `&lt;? extends Record&gt;`|1:-1 - 32767:2^63-1|String
 |Byte|BYTE|Single byte.
 Useful to store small 8-bit signed integers|`java.lang.Byte` or `byte`|-128 - +127|Any Number, String
 |Decimal|DECIMAL|Decimal numbers without rounding|`java.math.BigDecimal`| |Any Number, String

--- a/src/main/asciidoc/comparison/orientdb.adoc
+++ b/src/main/asciidoc/comparison/orientdb.adoc
@@ -9,7 +9,7 @@ This allowed to get rid of many legacy parts that makes OrientDB slow, heavy and
 Also, since OrientDB was the first Multi-Model project out there, a lot of work of the initial R&D and experiments are still in the OrientDB code base.
 You can consider ArcadeDB as the natural evolution of the legacy OrientDB project.
 
-If you're coming from OrientDB, please use the <<_orientdb-importer,OrientDB Importer>> tool to import an OrientDB export into an ArcadeDB database.
+If you're coming from OrientDB, please use the <<OrientDB-Importer,OrientDB Importer>> tool to import an OrientDB export into an ArcadeDB database.
 
 **Main similarities and differences**
 

--- a/src/main/asciidoc/comparison/orientdb.adoc
+++ b/src/main/asciidoc/comparison/orientdb.adoc
@@ -1,4 +1,4 @@
-[[_orientdb]]
+[[OrientDB]]
 [discrete]
 === OrientDB
 image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/comparison/orientdb.adoc" float=right]

--- a/src/main/asciidoc/concepts/basics.adoc
+++ b/src/main/asciidoc/concepts/basics.adoc
@@ -1,4 +1,3 @@
-[discrete]
 === Record
 
 A record is the smallest unit you can load from and store in the database.
@@ -74,7 +73,6 @@ Additionally, records can be accessed directly through their RIDs at{nbsp}O(1){n
 For this reason, you don't need to create a field to serve as the primary key as you do in Relational databases.
 
 [[Types]]
-[discrete]
 === Types
 
 The concept of the Type is taken from the http://en.wikipedia.org/wiki/Object-oriented_programming[Object Oriented Programming] paradigm, sometimes as 'Class'.
@@ -84,7 +82,7 @@ It is closest to the concept of a 'Table' in Relational databases and a 'Class' 
 Types can be schema-less, schema-full, or a mix.
 They can inherit from other types, creating a tree of types. http://en.wikipedia.org/wiki/Inheritance_%28object-oriented_programming%29[Inheritance], in this context, means that a subtype extends a parent type, inheriting all of its attributes.
 
-Each type has its own <<Bucket,buckets (data files)>>.
+Each type has its own <<Buckets,buckets (data files)>>.
 A type can support multiple buckets.
 When you execute a query against a type, it automatically fetches from all the buckets that are part of the type.
 When you create a new record, ArcadeDB selects the bucket to store it in using a <<_bucket-selection,configurable strategy>>.
@@ -97,7 +95,6 @@ Check if your Operative System has any limitation with the number of files suppo
 NOTE: You can query the defined types by executing the following SQL query: `select from schema:types`.
 
 [[Buckets]]
-[discrete]
 === Buckets
 
 Where types provide you with a logical framework for organizing data, buckets provide physical or in-memory space in which ArcadeDB actually stores the data.
@@ -107,7 +104,7 @@ You can have up to 2,147,483,648 buckets in a database.
 
 A bucket can only be part of one type. This means two types can not share the same bucket.
 
-When you create a new type, the <<_sql-create-type,`CREATE TYPE`>> statement automatically creates the physical buckets (files) that serve as the default location in which to store data for that type.
+When you create a new type, the <<SQL-Create-Type,`CREATE TYPE`>> statement automatically creates the physical buckets (files) that serve as the default location in which to store data for that type.
 ArcadeDB forms the bucket names by using the type name + underscore + a sequential number starting from 0. For example, the first bucket for the type `Beer` will be `Beer_0` and the correspondent file in the file system will be `Beer_0.31.65536.bucket`.
 ArcadeDB creates additional buckets for each type, (one for each CPU core on the server), to improve performance of parallelism.
 
@@ -125,7 +122,7 @@ In most cases you need indexes to speed up your queries, but in some use cases y
 ==== One bucket per period
 
 Consider an example where you create a type `Invoice`, with one bucket per year. `Invoice_2015` and `Invoice_2016`.
-You can query all invoices using the type as a target with the <<_sql-select,`SELECT`>> statement.
+You can query all invoices using the type as a target with the <<SQL-Select,`SELECT`>> statement.
 
 [source,sql]
 ----
@@ -133,7 +130,7 @@ arcadeDB> SELECT FROM Invoice
 ----
 
 In addition to this, you can filter the result set by the year.
-The type `Invoice` includes a `year` field, you can filter it through the <<_filtering,`WHERE`>> clause.
+The type `Invoice` includes a `year` field, you can filter it through the <<Filtering,`WHERE`>> clause.
 
 [source,sql]
 ----
@@ -167,7 +164,7 @@ CREATE VERTEX TYPE Customer BUCKET Customer_Europe,Customer_Americas,Customer_As
 ----
 
 Here we are using the graph model by creating a vertex type, but it's the same with documents.
-Use <<_sql-create-type,`CREATE DOCUMENT TYPE`>> instead.
+Use <<SQL-Create-Type,`CREATE DOCUMENT TYPE`>> instead.
 
 Now in your application store the vertices or documents in the right bucket, based on the location of such customer.
 You can use any API and set the bucket.
@@ -212,7 +209,6 @@ arcadeDB> SELECT FROM BUCKET:Customer_Europe_Italy,Customer_Europe_Spain
 ----
 
 [[Relationships]]
-[discrete]
 === Relationships
 
 ArcadeDB supports two kinds of relationships: **referenced** and **embedded**.
@@ -236,7 +232,7 @@ Customer Record A -------------> Record B Invoice
 
 When using Embedded relationships, ArcadeDB stores the relationship within the record that embeds it.
 These relationships are stronger than Reference relationships.
-You can represent it as a http://en.wikipedia.org/wiki/Type_diagram#Composition[UML Composition relationship].
+You can represent it as a http://en.wikipedia.org/wiki/Class_diagram#Composition[UML Composition relationship].
 
 Embedded records do not have their own <<RID,RID>>, given that you can't directly reference it through other records.
 It is only accessible through the container record.
@@ -259,12 +255,12 @@ arcadeDB> SELECT FROM Account WHERE address.city = 'Rome'
 ```
 
 [discrete]
-====# 1:1 and *n*:1 Embedded Relationships
+==== 1:1 and n:1 Embedded Relationships
 
 ArcadeDB expresses relationships of these kinds using the `EMBEDDED` type.
 
 [discrete]
-====# 1:*n* and *n*:*n* Embedded Relationships
+==== 1:n and n:n Embedded Relationships
 
 ArcadeDB expresses relationships of these kinds using a list or a map of links, such as:
 
@@ -278,7 +274,6 @@ In ArcadeDB, all Edges in the Graph model are bidirectional.
 This differs from the Document model, where relationships are always unidirectional, requiring the developer to maintain data integrity.
 In addition, ArcadeDB automatically maintains the consistency of all bidirectional relationships.
 
-[discrete]
 === Database
 
 Each server or Java VM can handle multiple database instances, but the database name must be unique.

--- a/src/main/asciidoc/concepts/basics.adoc
+++ b/src/main/asciidoc/concepts/basics.adoc
@@ -73,6 +73,7 @@ Each Record ID is immutable, universal, and is never reused.
 Additionally, records can be accessed directly through their RIDs at{nbsp}O(1){nbsp}complexity which means the query speed is constant, unaffected by database size.
 For this reason, you don't need to create a field to serve as the primary key as you do in Relational databases.
 
+[[Types]]
 [discrete]
 === Types
 
@@ -95,7 +96,7 @@ Check if your Operative System has any limitation with the number of files suppo
 
 NOTE: You can query the defined types by executing the following SQL query: `select from schema:types`.
 
-[[Bucket]]
+[[Buckets]]
 [discrete]
 === Buckets
 

--- a/src/main/asciidoc/concepts/inheritance.adoc
+++ b/src/main/asciidoc/concepts/inheritance.adoc
@@ -1,18 +1,16 @@
 
 [[Inheritance]]
-[discrete]
-### Inheritance
+=== Inheritance
 image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/concepts/inheritance.adoc" float=right]
 
 Unlike many Object-relational mapping tools, ArcadeDB does not split documents between different types.
 Each document resides in one or a number of buckets associated with its specific type.
-When you execute a query against a type that has subtypes, OrientDB searches the buckets of the target type and all subtypes.
+When you execute a query against a type that has subtypes, ArcadeDB searches the buckets of the target type and all subtypes.
 
 [discrete]
 #### Declaring Inheritance in Schema
 
 In developing your application, bear in mind that ArcadeDB needs to know the type inheritance relationship.
-This is an abstract concept that applies to both  [POJO's](../java/Object-DB-Interface.md#inheritance) and  [Documents](../java/Document-Database.md).
 
 For example,
 
@@ -25,7 +23,7 @@ DocumentType company = database.getSchema().createDocumentType("Company").addPar
 [discrete]
 #### Using Polymorphic Queries
 
-By default, OrientDB treats all queries as polymorphic.
+By default, ArcadeDB treats all queries as polymorphic.
 Using the example above, you can run the following query from the console:
 
 [source,sql]
@@ -49,7 +47,7 @@ By default, ArcadeDB creates a separate bucket for each type.
 It indicates this bucket by the `defaultBucketId` property in the type `OType` and indicates the bucket used by default when not specified.
 However, the type `OType` has a property `bucketIds`, (as `int[]`), that contains all the buckets able to contain the records of that type.  `bucketIds` and `defaultBucketId` are the same by default.
 
-When you execute a query against a type, OrientDB limits the result-sets to only the records of the buckets contained in the `bucketIds` property.
+When you execute a query against a type, ArcadeDB limits the result-sets to only the records of the buckets contained in the `bucketIds` property.
 For example,
 
 [source,sql]

--- a/src/main/asciidoc/concepts/transactions.adoc
+++ b/src/main/asciidoc/concepts/transactions.adoc
@@ -1,5 +1,4 @@
 
-[discrete]
 === Transactions
 image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/concepts/transactions.adoc" float=right]
 
@@ -10,30 +9,36 @@ Transactions in a database environment have two main purposes:
 - to provide isolation between programs accessing a database concurrently.
 If this isolation is not provided, the program's outcome are possibly erroneous.
 
-A database transaction, by definition, must be <<_-atomicity,atomic>>, [consistent](#consistency), [isolated](#isolation) and [durable](#durability).
-Database practitioners often refer to these properties of database transactions using the acronym <<_-acid-properties,ACID>>).
---- http://en.wikipedia.org/wiki/Database_transaction[Wikipedia]
+A database transaction, by definition, must be <<Atomicity,atomic>>, <<Consistency,consistent>>, <<Isolation,isolated>> and <<Durability,durable>>.
+Database practitioners often refer to these properties of database transactions using the acronym <<ACID-Properties,ACID>>).
+- http://en.wikipedia.org/wiki/Database_transaction[Wikipedia]
 
-ArcadeDB is an <<_-acid-properties,ACID>> compliant DBMS.
+ArcadeDB is an <<ACID-Properties,ACID>> compliant DBMS.
 
 NOTE: ArcadeDB keeps the transaction on client RAM, so the transaction size is affected by the available RAM (Heap memory) on JVM.
 For transactions involving many records, consider to split it in multiple transactions.
 
+[[ACID-Properties]]
+[discrete]
+==== ACID Properties
+
+[[Atomicity]]
 [discrete]
 ==== Atomicity
 
 "Atomicity requires that each transaction is 'all or nothing': if one part of the transaction fails, the entire transaction fails, and the database state is left unchanged.
 An atomic system must guarantee atomicity in each and every situation, including power failures, errors, and crashes.
-To the outside world, a committed transaction appears (by its effects on the database) to be indivisible ("atomic"), and an aborted transaction does not happen." - http://en.wikipedia.org/wiki/ACID[WikiPedia]
+To the outside world, a committed transaction appears (by its effects on the database) to be indivisible ("atomic"), and an aborted transaction does not happen." - https://en.wikipedia.org/wiki/ACID#Atomicity[Wikipedia]
 
+[[Consistency]]
 [discrete]
 ==== Consistency
 
 "The consistency property ensures that any transaction will bring the database from one valid state to another.
 Any data written to the database must be valid according to all defined rules, including but not limited to constraints, cascades, triggers, and any combination thereof.
-This does not guarantee correctness of the transaction in all ways the application programmer might have wanted (that is the responsibility of application-level code) but merely that any programming errors do not violate any defined rules." - http://en.wikipedia.org/wiki/ACID[WikiPedia]
+This does not guarantee correctness of the transaction in all ways the application programmer might have wanted (that is the responsibility of application-level code) but merely that any programming errors do not violate any defined rules." - http://en.wikipedia.org/wiki/ACID#Consistency_(Correctness)[Wikipedia]
 
-ArcadeDB uses the MVCC to assure consistency by versioning the page where the record are stored.
+ArcadeDB uses the http://en.wikipedia.org/wiki/Multiversion_concurrency_control[MVCC] to assure consistency by versioning the page where the record are stored.
 
 Look at this example:
 
@@ -50,12 +55,13 @@ Look at this example:
 |8| commit |  | 10 -> 11 = Error, in database x already is at 11
 |===
 
+[[Isolation]]
 [discrete]
 ==== Isolation
 
 "The isolation property ensures that the concurrent execution of transactions results in a system state that would be obtained if transactions were executed serially, i.e. one after the other.
 Providing isolation is the main goal of concurrency control.
-Depending on concurrency control method, the effects of an incomplete transaction might not even be visible to another transaction." - http://en.wikipedia.org/wiki/ACID[WikiPedia]
+Depending on concurrency control method, the effects of an incomplete transaction might not even be visible to another transaction." - https://en.wikipedia.org/wiki/ACID#Isolation[Wikipedia]
 
 
 Using `remote` access all the commands are executed on the server, so out of transaction scope.
@@ -93,18 +99,22 @@ At operation 7 the client 1 continues to read the same version of x read in oper
 
 At operation 7 the client 1 reads the version of y which was written at operation 6 by client 2. This is because it never reads y before.
 
+[[Durability]]
 [discrete]
 ==== Durability
 
 "Durability means that once a transaction has been committed, it will remain so, even in the event of power loss, crashes, or errors.
 In a relational database, for instance, once a group of SQL statements execute, the results need to be stored permanently (even if the database crashes immediately thereafter).
-To defend against power loss, transactions (or their effects) must be recorded in a non-volatile memory." - http://en.wikipedia.org/wiki/ACID[WikiPedia]
+To defend against power loss, transactions (or their effects) must be recorded in a non-volatile memory." - https://en.wikipedia.org/wiki/ACID#Durability[Wikipedia]
 
 [discrete]
 ===== Fail-over
 
 An ArcadeDB instance can fail for several reasons:
-- HW problems, such as loss of power or disk error - SW problems, such as a Operating System crash - Application problem, such as a bug that crashes your application that is connected to the Orient engine.
+
+- HW problems, such as loss of power or disk error 
+- SW problems, such as a Operating System crash 
+- Application problem, such as a bug that crashes your application that is connected to the ArcadeDB engine.
 
 You can use the ArcadeDB engine directly in the same process of your application.
 This gives superior performance due to the lack of inter-process communication.
@@ -123,9 +133,9 @@ ArcadeDB has different levels of durability based on storage type, configuration
 [discrete]
 ==== Optimistic Transaction
 
-This mode uses the well known [Multi Version Control System http://en.wikipedia.org/wiki/Multiversion_concurrency_control[MVCC] by allowing multiple reads and writes on the same records.
+This mode uses the well known Multi Version Control System http://en.wikipedia.org/wiki/Multiversion_concurrency_control[MVCC] by allowing multiple reads and writes on the same records.
 The integrity check is made on commit.
-If the record has been saved by another transaction in the interim, then an OConcurrentModificationException will be thrown.
+If the record has been saved by another transaction in the interim, then an `OConcurrentModificationException` will be thrown.
 The application can choose either to repeat the transaction or abort it.
 
 NOTE: ArcadeDB keeps the whole transaction on client's RAM, so the transaction size is affected by the available RAM (Heap) memory on JVM.

--- a/src/main/asciidoc/content.adoc
+++ b/src/main/asciidoc/content.adoc
@@ -4,29 +4,29 @@ Skip the boring parts and check this out:
 
 * <<Quick-Start-Docker,Run ArcadeDB with Open Beer demo database in 30 seconds>>
 * Checkout the Open Source project on https://github.com/ArcadeData/arcadedb[GitHub]
-* What is <<_multi-model,Multi-Model>>?
+* What is <<Multi-Model,Multi-Model>>?
 * ArcadeDB supports the following models:
-** <<_graph-model,Graph Model>> (compatible with Gremlin and OrientDB SQL)
-** <<_document-model,Document Database>> (compatible with the MongoDB driver and MongoDB queries)
-** <<_keyvalue-model,Key/Value>> (compatible with the Redis driver)
-** <<_timeseries-model,Time Series>>
+** <<Graph-Model,Graph>> (compatible with Gremlin and OrientDB SQL)
+** <<Document-Model,Document>> (compatible with the MongoDB driver and MongoDB queries)
+** <<KeyValue-Model,Key/Value>> (compatible with the Redis driver)
+** <<TimeSeries-Model,Time Series>>
 
 * ArcadeDB understands multiple languages:
-** <<_sql,SQL>> (inspired from OrientDB SQL dialect that supports pattern matching on graphs)
-** <<_open-cypher,Cypher>>
-** <<_gremlin-api,Apache Gremlin (Apache Tinkerpop v3.4.x)>>
-** <<_mongodb-api,MongoDB Query Language>>
+** <<SQL,SQL>> (inspired from OrientDB SQL dialect that supports pattern matching on graphs)
+** <<Open-Cypher,Cypher>>
+** <<Gremlin-API,Apache Gremlin (Apache Tinkerpop v3.4.x)>>
+** <<MongoDB-API,MongoDB Query Language>>
 
 * ArcadeDB can be used as:
-** <<_,Embedded>> from any language on top of the Java Virtual Machine
-** Remotely by using <<_http-api,HTTP/JSON>>
-** Remotely by using a <<_postgres-driver,Postgres driver>> (ArcadeDB implements Postgres Wire protocol)
-** Remotely by using a <<_mongodb-api,MongoDB driver>> (only a subset of the operations are implemented)
-** Remotely by using a <<_redis-api,Redis driver>> (only a subset of the operations are implemented)
-* Tutorials: <<_java-tutorial,Java Tutorial>>
-* Tools: <<_console-tutorial,Working with the Console Tutorial>>
-* Misc: <<_docker,Docker>>, <<_kubernetes,Kubernetes>>
-* Migrating from <<_orientdb,OrientDB>>
+** <<Embedded-Server,Embedded>> from any language on top of the Java Virtual Machine
+** Remotely by using <<HTTP-API,HTTP/JSON>>
+** Remotely by using a <<Postgres-Driver,Postgres driver>> (ArcadeDB implements Postgres Wire protocol)
+** Remotely by using a <<MongoDB-API,MongoDB driver>> (only a subset of the operations are implemented)
+** Remotely by using a <<Redis-API,Redis driver>> (only a subset of the operations are implemented)
+* Tutorials: <<Java-Tutorial,Java Tutorial>>
+* Tools: <<Console-Tutorial,Working with the Console Tutorial>>
+* Misc: <<Docker,Docker>>, <<Kubernetes,Kubernetes>>
+* Migrating from <<OrientDB,OrientDB>>
 
 include::introduction/chapter.adoc[]
 

--- a/src/main/asciidoc/introduction/multimodel.adoc
+++ b/src/main/asciidoc/introduction/multimodel.adoc
@@ -1,3 +1,4 @@
+[[Multi-Model]]
 === Multi Model
 image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/introduction/multimodel.adoc" float="right"]
 
@@ -5,7 +6,7 @@ The ArcadeDB engine supports **Graph**, **Document**, **Key/Value**, and **Time-
 
 image::https://arcadedb.com/assets/images/multi-model-small.png[align="center"]
 
-
+[[Graph-Model]]
 ==== Graph Model
 
 A graph represents a network-like structure consisting of Vertices (also known as Nodes) interconnected by Edges (also known as Arcs). ArcadeDB's graph model is represented by the concept of a property graph, which defines the following:

--- a/src/main/asciidoc/introduction/multimodel.adoc
+++ b/src/main/asciidoc/introduction/multimodel.adoc
@@ -39,19 +39,19 @@ In addition to mandatory properties, each vertex or edge can also hold a set of 
 [[Document-Model]]
 ==== Document Model
 
-The data in this model is stored inside documents. A document is a set of key/value pairs (also referred to as fields or properties), where the key allows access to its value. Values can hold primitive data types, embedded documents, or arrays of other values. Documents are not typically forced to have a schema, which can be advantageous, because they remain flexible and easy to modify. Documents are stored in collections, enabling developers to group data as they decide. ArcadeDB uses the concepts of "[types](Concepts.md#type)" and "<<Bucket,Bucket>>" as its form of "collections" for grouping documents. This provides several benefits, which we will discuss in further sections of the documentation.
+The data in this model is stored inside documents. A document is a set of key/value pairs (also referred to as fields or properties), where the key allows access to its value. Values can hold primitive data types, embedded documents, or arrays of other values. Documents are not typically forced to have a schema, which can be advantageous, because they remain flexible and easy to modify. Documents are stored in collections, enabling developers to group data as they decide. ArcadeDB uses the concepts of "<<Types,Types>>" and "<<Buckets,Buckets>>" as its form of "collections" for grouping documents. This provides several benefits, which we will discuss in further sections of the documentation.
 
-ArcadeDB's Document model also adds the concept of a "<<Link,Link>>" as a relationship between documents. With ArcadeDB, you can decide whether to embed documents or link to them directly. When you fetch a document, all the links are automatically resolved by ArcadeDB. This is a major difference to other Document Databases, like MongoDB or CouchDB, where the developer must handle any and all relationships between the documents herself.
+ArcadeDB's Document model also adds the concept of a "<<Relationships,Relationship>>" between documents. With ArcadeDB, you can decide whether to embed documents or link to them directly. When you fetch a document, all the links are automatically resolved by ArcadeDB. This is a major difference to other Document Databases, like MongoDB or CouchDB, where the developer must handle any and all relationships between the documents herself.
 
 The table below illustrates the comparison between the relational model, the document model, and the ArcadeDB document model:
 
 [%header,cols=3]
 |===
 | Relational Model | Document Model   | ArcadeDB Document Model
-| Table            | Collection       | <<Type,Type>> or <<Bucket,Bucket>>
+| Table            | Collection       | <<Types,Type>> or <<Buckets,Bucket>>
 | Row              | Document         | Document
 | Column           | Key/value pair   | Document property
-| Relationship     | not available    | <<Relationships,Relationships>>
+| Relationship     | not available    | <<Relationships,Relationship>>
 |===
 
 [[KeyValue-Model]]
@@ -68,10 +68,10 @@ The table below illustrates the comparison between the relational model, the Key
 [%header,cols=3]
 |===
 | Relational Model | Key/Value Model   | ArcadeDB Key/Value Model
-| Table            | Bucket           | <<Bucket,Bucket>>
+| Table            | Bucket           | <<Buckets,Bucket>>
 | Row              | Key/Value pair   | Document
 | Column           | not available    | Document field or Vertex/Edge property
-| Relationship     | not available    | <<Relationships,Relationships>>
+| Relationship     | not available    | <<Relationships,Relationship>>
 |===
 
 

--- a/src/main/asciidoc/introduction/run.adoc
+++ b/src/main/asciidoc/introduction/run.adoc
@@ -34,6 +34,6 @@ Feel free to use it if your application is running on a JVM.
 
 You can spin up as many ArcadeDB servers you want to have a HA setup and scale up with queries that can be executed on any servers.
 ArcadeDB uses a RAFT based election system to guarantee the consistency of the database.
-For more information look at <<#_high-availability,High Availability>>.
+For more information look at <<#High-Availability,High Availability>>.
 
 

--- a/src/main/asciidoc/server/chapter.adoc
+++ b/src/main/asciidoc/server/chapter.adoc
@@ -3,12 +3,13 @@
 
 include::server.adoc[]
 
-include::docker.adoc[]
+include::settings.adoc[]
 
 include::ha.adoc[]
 
+include::embed-server.adoc[]
+
+include::docker.adoc[]
+
 include::kubernetes.adoc[]
 
-include::settings.adoc[]
-
-include::embed-server.adoc[]

--- a/src/main/asciidoc/server/docker.adoc
+++ b/src/main/asciidoc/server/docker.adoc
@@ -1,3 +1,4 @@
+[[Docker]]
 === Docker
 image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/server/docker.adoc" float="right"]
 

--- a/src/main/asciidoc/server/docker.adoc
+++ b/src/main/asciidoc/server/docker.adoc
@@ -59,7 +59,7 @@ image::../images/openbeer-demo-graph.png[alt="Demo Database Graph",align="center
 [[DockerTuning]]
 ==== Tuning
 
-In general, the RAM allocated for the JVM should be <=80% of the container RAM. The default Dockerfile for ArcadeDB sets 2 GB of RAM for ArcadeDB (`-Xms2G -Xmx2G`), so you should allocate at least 2.3G to the Docker container running exclusively ArcadeDB.
+In general, the RAM allocated for the JVM should be ≤80% of the container RAM. The default Dockerfile for ArcadeDB sets 2 GB of RAM for ArcadeDB (`-Xms2G -Xmx2G`), so you should allocate at least 2.3G to the Docker container running exclusively ArcadeDB.
 
 To run ArcadeDB with 1G docker container, you could start ArcadeDB by using 800M for ArcadeDB's server RAM by setting `ARCADEDB_OPTS_MEMORY` variable with Docker:
 

--- a/src/main/asciidoc/server/embed-server.adoc
+++ b/src/main/asciidoc/server/embed-server.adoc
@@ -1,3 +1,4 @@
+[[Embedded-Server]]
 === Embedded Server
 
 image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/server/embed-server.adoc" float="right"]

--- a/src/main/asciidoc/server/ha.adoc
+++ b/src/main/asciidoc/server/ha.adoc
@@ -1,3 +1,4 @@
+[[High-Availability]]
 === High Availability
 
 image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/server/ha.adoc" float="right"]

--- a/src/main/asciidoc/server/ha.adoc
+++ b/src/main/asciidoc/server/ha.adoc
@@ -8,7 +8,7 @@ ArcadeDB supports a High Availability mode where multiple servers share the same
 In order to start an ArcadeDB server with the support for replication, you need to:
 
 1. Enable the HA module by setting the configuration `arcadedb.ha.enabled` to `true`
-2. Define the servers that are part of the clusters (if you are using Kubernetes, look at <<_kubernetes,Kubernetes>> paragraph).
+2. Define the servers that are part of the clusters (if you are using Kubernetes, look at <<Kubernetes,Kubernetes>> paragraph).
 To setup the server list, define the `arcadedb.ha.serverList` setting by separating the servers with commas (`,`) and using the following format for servers: `<hostname/ip-address[:port]>`.
 The default port is `2424` if not specified.
 3. Define the local server name by setting the `arcadedb.server.name` configuration.
@@ -150,7 +150,7 @@ Check UDP Broadcast protocol is enabled in your LAN on both firewalls and router
 
 ==== HA Settings
 
-The following <<#_settings,settings>> are used by the High Availability module:
+The following <<Settings,settings>> are used by the High Availability module:
 
 [%header,cols=3]
 |===

--- a/src/main/asciidoc/server/kubernetes.adoc
+++ b/src/main/asciidoc/server/kubernetes.adoc
@@ -1,3 +1,4 @@
+[[Kubernetes]]
 === Kubernetes
 
 image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/server/kubernetes.adoc" float="right"]

--- a/src/main/asciidoc/server/server.adoc
+++ b/src/main/asciidoc/server/server.adoc
@@ -69,7 +69,7 @@ By default, the following components start with the server:
 
 In the output above, the name `ArcadeDB_0` is the server name.
 By default, `ArcadeDB_0` is used.
-To specify a different name define it with the setting <<#_settings,`server.name`>>, example:
+To specify a different name define it with the setting <<Settings,`server.name`>>, example:
 
 ```shell
 ~/arcadedb $ bin/server.sh -Darcadedb.server.name=ArcadeDB_Europe_0
@@ -79,7 +79,7 @@ In HA configuration, it's mandatory all the servers in cluster have different na
 
 ==== Create default database(s)
 
-Instead of starting a server and then connect to it to create the default databases, ArcadeDB Server takes an initial default databases list by using the setting <<#_settings,`server.defaultDatabases`>>.
+Instead of starting a server and then connect to it to create the default databases, ArcadeDB Server takes an initial default databases list by using the setting <<Settings,`server.defaultDatabases`>>.
 
 ```shell
 ~/arcadedb $ bin/server.sh -Darcadedb.server.defaultDatabases=Universe[elon:musk]

--- a/src/main/asciidoc/server/settings.adoc
+++ b/src/main/asciidoc/server/settings.adoc
@@ -1,4 +1,5 @@
-=== Settings
+[[Changing-Settings]]
+=== Changing Settings
 image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/server/settings.adoc" float="right"]
 
 To change the default value of a setting, always put `arcadedb.` as a prefix. Example:
@@ -15,7 +16,7 @@ To change the same setting via Java code:
 GlobalConfiguration.findByKey("arcadedb.dumpConfigAtStartup").setValue(true);
 ----
 
-Check <<Appendix-A,Appendix A>> for all the available settings.
+Check the <<Settings,Appendix>> for all the available settings.
 
 ==== RAM Configuration
 

--- a/src/main/asciidoc/sql/SQL-Backup-Database.adoc
+++ b/src/main/asciidoc/sql/SQL-Backup-Database.adoc
@@ -1,5 +1,5 @@
+[[SQL-Backup-Database]]
 [discrete]
-
 === SQL - `BACKUP DATABASE`
 
 image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Backup-Database.md" float=right]

--- a/src/main/asciidoc/sql/SQL-Create-Type.adoc
+++ b/src/main/asciidoc/sql/SQL-Create-Type.adoc
@@ -1,3 +1,4 @@
+[[SQL-Create-Type]]
 [discrete]
 === SQL - `CREATE TYPE`
 

--- a/src/main/asciidoc/sql/SQL-Import-Database.adoc
+++ b/src/main/asciidoc/sql/SQL-Import-Database.adoc
@@ -1,5 +1,5 @@
+[[SQL-Import-Database]]
 [discrete]
-
 === SQL - `IMPORT DATABASE`
 
 image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Import-Database.md" float=right]

--- a/src/main/asciidoc/sql/SQL-Select.adoc
+++ b/src/main/asciidoc/sql/SQL-Select.adoc
@@ -1,5 +1,5 @@
+[[SQL-Select]]
 [discrete]
-
 === SQL - `SELECT`
 
 image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Select.md" float=right]

--- a/src/main/asciidoc/sql/SQL-Where.adoc
+++ b/src/main/asciidoc/sql/SQL-Where.adoc
@@ -1,5 +1,5 @@
 [discrete]
-
+[[Filtering]]
 === Filtering
 
 image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Where.md" float=right]

--- a/src/main/asciidoc/sql/chapter.adoc
+++ b/src/main/asciidoc/sql/chapter.adoc
@@ -1,3 +1,4 @@
+[[SQL]]
 == SQL
 
 [[SQL-Commands]]

--- a/src/main/asciidoc/studio/main.adoc
+++ b/src/main/asciidoc/studio/main.adoc
@@ -23,6 +23,7 @@ In order to execute a command (or query), select the language first. By default 
 * *Apache Tinkerpop Gremlin* (only for graphs)
 * *Open Cypher* (only for graphs)
 * *MongoDB* (only for documents)
+* *GraphQL*
 
 image::../images/studio-command-select-language.png[]
 

--- a/src/main/asciidoc/tools/backup.adoc
+++ b/src/main/asciidoc/tools/backup.adoc
@@ -6,4 +6,4 @@ image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/
 ArcadeDB allows to execute a non-stop backup of a database while it is used without blocking writes or affecting performance.
 You can execute the backup of a database from SQL.
 
-Look at <<_sql-backup-database,Backup Database SQL command>> for more information.
+Look at <<SQL-Backup-Database,Backup Database SQL command>> for more information.

--- a/src/main/asciidoc/tools/importer.adoc
+++ b/src/main/asciidoc/tools/importer.adoc
@@ -4,8 +4,8 @@ image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/
 
 ArcadeDB is able to import automatically any dataset in the following formats:
 
-- https://orientdb.org[OrientDB database export]
-- https://neo4j.com[Neo4j database export]
+- https://orientdb.org[OrientDB] database export
+- https://neo4j.com[Neo4j] database export
 - Generic XML files
 - Generic JSON files
 - Generic CSV files
@@ -59,6 +59,6 @@ Example of importing New York Taxi dataset in CSV format. The first line of the 
 
 See also:
 
-<<_sql-import-database,SQL Import Database command>>
-<<_neo4j-importer,Neo4j Importer>>
-<<_orientdb-importer,OrientDB Importer>>
+<<SQL-Import-Database,SQL Import Database command>>
+<<Neo4j-Importer,Neo4j Importer>>
+<<OrientDB-Importer,OrientDB Importer>>

--- a/src/main/asciidoc/tools/neo4j-importer.adoc
+++ b/src/main/asciidoc/tools/neo4j-importer.adoc
@@ -1,3 +1,4 @@
+[[Neo4j-Importer]]
 ==== Neo4j Importer
 
 image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/tools/neo4j-importer.adoc" float=right]
@@ -43,7 +44,7 @@ This is the example taken from Neo4j documentation about Export to JSON.
 As you can see, the file contains one json per line.
 First all the nodes (vertices), then the relationships (edges).
 
-To import a database use the <<_sql-import-database,Import Database>> command from API, Studio or Console. Below you can find an example of importing the Neo4j's PanamaPapers database by using ArcadeDB <<Console,Console>>.
+To import a database use the <<SQL-Import-Database,Import Database>> command from API, Studio or Console. Below you can find an example of importing the Neo4j's PanamaPapers database by using ArcadeDB <<Console,Console>>.
 
 [source,shell]
 ----

--- a/src/main/asciidoc/tools/orientdb-importer.adoc
+++ b/src/main/asciidoc/tools/orientdb-importer.adoc
@@ -1,3 +1,4 @@
+[[OrientDB-Importer]]
 ==== OrientDB Importer
 image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/tools/orientdb-importer.adoc" float=right]
 
@@ -5,7 +6,7 @@ ArcadeDB is able to import a database exported from OrientDB in JSON format.
 
 For more information about how to export a database from OrientDB, look at http://orientdb.com/docs/3.1.x/console/Console-Command-Export.html[Export Database].
 
-To import a database use the <<_sql-import-database,Import Database>> command from API, Studio or Console. Below you can find an example of importing a OrientDB database by using ArcadeDB <<Console,Console>>.
+To import a database use the <<SQL-Import-Database,Import Database>> command from API, Studio or Console. Below you can find an example of importing a OrientDB database by using ArcadeDB <<Console,Console>>.
 
 [source,shell]
 ----

--- a/src/main/asciidoc/tools/upgrade.adoc
+++ b/src/main/asciidoc/tools/upgrade.adoc
@@ -16,4 +16,4 @@ The migration is completely automatic and transparent.
 === Downgrade to older version of ArcadeDB
 
 In the case you need to downgrade to an older version of ArcadeDB, check the binary compatibility between the versions.
-ArcadeDB uses the [https://semver.org/,semantic versioning] with 100% compatibility for migration of databases up or down between patch version (the Z in X.Y.Z). To downgrade to a minor or major, the safest way is to export the database with the newest version and re-import the database with the older version.
+ArcadeDB uses the https://semver.org[semantic versioning] with 100% compatibility for migration of databases up or down between patch version (the Z in X.Y.Z). To downgrade to a minor or major, the safest way is to export the database with the newest version and re-import the database with the older version.


### PR DESCRIPTION
I fixed linking issues ( https://github.com/ArcadeData/arcadedb-docs/issues/43 ) as well as some other syntax issues in Sections 1,2,3,4,5,6,7,9,10,11.
FYI: In Section 7 and 8 still some linking issues remain.

Other Changes:

* De-discretized sub-sections in Section 3 to make sub-sections appear in ToC
* Rearrange sequence of sub-sections in Section 4.
* Removed double content in Section 7.1
* De-discretized "Java Reference" Section so it appears in Toc