### PR TITLE
Fixes 'Edit this section' links to arcadedb-docs adoc URLs.

### DIFF
--- a/src/main/asciidoc/sql/SQL-Align-Database.adoc
+++ b/src/main/asciidoc/sql/SQL-Align-Database.adoc
@@ -2,7 +2,7 @@
 
 === SQL - `ALIGN DATABASE`
 
-image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Align-Database.md" float=right]
+image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Align-Database.adoc" float=right]
 
 Executes a distributed alignment of the database. It must be executed on the Leader server. The alignment computes a checksum of
 each file and sends them to the replica nodes. Each replica node will compute the checksum on its own files. The files that are

--- a/src/main/asciidoc/sql/SQL-Alter-Database.adoc
+++ b/src/main/asciidoc/sql/SQL-Alter-Database.adoc
@@ -2,7 +2,7 @@
 
 === SQL - `ALTER DATABASE`
 
-image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Alter-Database.md" float=right]
+image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Alter-Database.adoc" float=right]
 
 Change a database setting. You can find the available settings in <<Settings,Settings>> appendix. The update is persistent.
 

--- a/src/main/asciidoc/sql/SQL-Alter-Type.adoc
+++ b/src/main/asciidoc/sql/SQL-Alter-Type.adoc
@@ -2,7 +2,7 @@
 
 === SQL - `ALTER TYPE`
 
-image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Alter-Type.md" float=right]
+image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Alter-Type.adoc" float=right]
 
 Change a type defined in the schema. The change is persistent.
 

--- a/src/main/asciidoc/sql/SQL-Backup-Database.adoc
+++ b/src/main/asciidoc/sql/SQL-Backup-Database.adoc
@@ -1,8 +1,7 @@
-[[SQL-Backup-Database]]
 [discrete]
 === SQL - `BACKUP DATABASE`
 
-image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Backup-Database.md" float=right]
+image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Backup-Database.adoc" float=right]
 
 Executes a backup of the current database. The resulting file is a compressed archive using ZIP as algorithm. The archive contains
 the database directory without the transaction logs. The backup is executed taking a snapshot of the database at the time the

--- a/src/main/asciidoc/sql/SQL-Check-Database.adoc
+++ b/src/main/asciidoc/sql/SQL-Check-Database.adoc
@@ -2,7 +2,7 @@
 
 === SQL - `CHECK DATABASE`
 
-image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Check-Database.md" float=right]
+image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Check-Database.adoc" float=right]
 
 Executes an integrity check and in case of a repair of the database. This command analyzes the following things:
 

--- a/src/main/asciidoc/sql/SQL-Create-Bucket.adoc
+++ b/src/main/asciidoc/sql/SQL-Create-Bucket.adoc
@@ -2,7 +2,7 @@
 
 === SQL - `CREATE BUCKET`
 
-image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Create-Bucket.md" float=right]
+image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Create-Bucket.adoc" float=right]
 
 Creates a new bucket in the database. Once created, you can use the bucket to save records by specifying its name during saves. If you want to add the new bucket to a type, follow its creation with the <<`ALTER TYPE`,SQL-Alter-Type>> command, using the `ADDBUCKET` option.
 

--- a/src/main/asciidoc/sql/SQL-Create-Edge.adoc
+++ b/src/main/asciidoc/sql/SQL-Create-Edge.adoc
@@ -2,7 +2,7 @@
 
 === SQL - `CREATE EDGE`
 
-image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Create-Edge.md" float=right]
+image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Create-Edge.adoc" float=right]
 
 Creates a new edge in the database.
 

--- a/src/main/asciidoc/sql/SQL-Create-Index.adoc
+++ b/src/main/asciidoc/sql/SQL-Create-Index.adoc
@@ -2,7 +2,7 @@
 
 === SQL - `CREATE INDEX`
 
-image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Create-Index.md" float=right]
+image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Create-Index.adoc" float=right]
 
 Creates a new index. Indexes can be
 - *Unique* Where they don't allow duplicates.

--- a/src/main/asciidoc/sql/SQL-Create-Property.adoc
+++ b/src/main/asciidoc/sql/SQL-Create-Property.adoc
@@ -2,7 +2,7 @@
 
 === SQL - `CREATE PROPERTY`
 
-image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Create-Property.md" float=right]
+image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Create-Property.adoc" float=right]
 
 Creates a new property in the schema. It requires that the type for the property already exist on the database.
 

--- a/src/main/asciidoc/sql/SQL-Create-Type.adoc
+++ b/src/main/asciidoc/sql/SQL-Create-Type.adoc
@@ -1,8 +1,7 @@
-[[SQL-Create-Type]]
 [discrete]
 === SQL - `CREATE TYPE`
 
-image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Create-Type.md" float=right]
+image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Create-Type.adoc" float=right]
 
 Creates a new type in the schema.
 

--- a/src/main/asciidoc/sql/SQL-Create-Vertex.adoc
+++ b/src/main/asciidoc/sql/SQL-Create-Vertex.adoc
@@ -2,7 +2,7 @@
 
 === SQL - `CREATE VERTEX`
 
-image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Create-Vertex.md" float=right]
+image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Create-Vertex.adoc" float=right]
 
 Creates a new vertex in the database.
 

--- a/src/main/asciidoc/sql/SQL-Delete.adoc
+++ b/src/main/asciidoc/sql/SQL-Delete.adoc
@@ -1,7 +1,7 @@
 [discrete]
 === SQL - `DELETE`
 
-image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Delete.md" float=right]
+image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Delete.adoc" float=right]
 
 Removes one or more records from the database. You can refine the set of records that it removes using the <<_filtering,`WHERE`>> clause.
 

--- a/src/main/asciidoc/sql/SQL-Drop-Bucket.adoc
+++ b/src/main/asciidoc/sql/SQL-Drop-Bucket.adoc
@@ -1,8 +1,7 @@
 [discrete]
-
 === SQL - `DROP BUCKET`
 
-image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Drop-Bucket.md" float=right]
+image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Drop-Bucket.adoc" float=right]
 
 Removes the bucket and all of its content. This operation is permanent and cannot be rolled back.
 

--- a/src/main/asciidoc/sql/SQL-Drop-Index.adoc
+++ b/src/main/asciidoc/sql/SQL-Drop-Index.adoc
@@ -2,7 +2,7 @@
 
 === SQL - `DROP INDEX`
 
-image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Drop-Index.md" float=right]
+image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Drop-Index.adoc" float=right]
 
 Removes an index from a property defined in the schema.
 

--- a/src/main/asciidoc/sql/SQL-Drop-Property.adoc
+++ b/src/main/asciidoc/sql/SQL-Drop-Property.adoc
@@ -2,7 +2,7 @@
 
 === SQL - `DROP PROPERTY`
 
-image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Drop-Property.md" float=right]
+image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Drop-Property.adoc" float=right]
 
 Removes a property from the schema. Does not remove the property values in the records, it just changes the schema information. Records continue to have the property values, if any.
 

--- a/src/main/asciidoc/sql/SQL-Drop-Type.adoc
+++ b/src/main/asciidoc/sql/SQL-Drop-Type.adoc
@@ -2,7 +2,7 @@
 
 === SQL - `DROP TYPE`
 
-image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Drop-Type.md" float=right]
+image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Drop-Type.adoc" float=right]
 
 Removes a type from the schema.
 

--- a/src/main/asciidoc/sql/SQL-Explain.adoc
+++ b/src/main/asciidoc/sql/SQL-Explain.adoc
@@ -2,7 +2,7 @@
 
 === SQL - `EXPLAIN`
 
-image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Explain.md" float=right]
+image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Explain.adoc" float=right]
 
 EXPLAIN SQL command returns information about query execution planning of a specific statement, without executing the statement itself.
 

--- a/src/main/asciidoc/sql/SQL-Export-Database.adoc
+++ b/src/main/asciidoc/sql/SQL-Export-Database.adoc
@@ -2,7 +2,7 @@
 
 === SQL - `EXPORT DATABASE`
 
-image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Export-Database.md" float=right]
+image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Export-Database.adoc" float=right]
 
 Exports a database in the `exports` directory under the root directory where ArcadeDB is running.
 

--- a/src/main/asciidoc/sql/SQL-Functions.adoc
+++ b/src/main/asciidoc/sql/SQL-Functions.adoc
@@ -2,7 +2,7 @@
 [[SQL-Functions]]
 === Functions
 
-image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Functions.md" float=right]
+image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Functions.adoc" float=right]
 
 SQL Functions are all the functions bundled with OrientDB SQL engine. Look also to link:SQL-Methods.md[SQL Methods].
 

--- a/src/main/asciidoc/sql/SQL-Import-Database.adoc
+++ b/src/main/asciidoc/sql/SQL-Import-Database.adoc
@@ -2,7 +2,7 @@
 [discrete]
 === SQL - `IMPORT DATABASE`
 
-image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Import-Database.md" float=right]
+image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Import-Database.adoc" float=right]
 
 Executes an import of the database into the current one. Usually an import database is executed on an empty database, but it is
 possible to execute on any database. In case of conflict (unique index key already existent, etc.), the conflicting records will not

--- a/src/main/asciidoc/sql/SQL-Insert.adoc
+++ b/src/main/asciidoc/sql/SQL-Insert.adoc
@@ -2,7 +2,7 @@
 
 === SQL - `INSERT`
 
-image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Insert.md" float=right]
+image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Insert.adoc" float=right]
 
 The <<SQL-Insert,`INSERT`>> command creates a new record in the database. Records can be schema-less or follow rules specified in your model.
 

--- a/src/main/asciidoc/sql/SQL-Introduction.adoc
+++ b/src/main/asciidoc/sql/SQL-Introduction.adoc
@@ -2,7 +2,7 @@
 
 === Introduction
 
-image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Introduction.md" float=right]
+image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Introduction.adoc" float=right]
 
 When it comes to query languages, SQL is the most widely recognized standard. The majority of developers have experience and are
 comfortable with SQL. For this reason ArcadeDB uses SQL as its query language and adds some extensions to enable graph

--- a/src/main/asciidoc/sql/SQL-Match.adoc
+++ b/src/main/asciidoc/sql/SQL-Match.adoc
@@ -2,7 +2,7 @@
 
 === SQL - `MATCH`
 
-image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Match.md" float=right]
+image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Match.adoc" float=right]
 
 Queries the database in a declarative manner, using pattern matching.
 

--- a/src/main/asciidoc/sql/SQL-Methods.adoc
+++ b/src/main/asciidoc/sql/SQL-Methods.adoc
@@ -1,7 +1,7 @@
 [discrete]
 === Methods
 
-image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Methods.md" float=right]
+image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Methods.adoc" float=right]
 
 SQL Methods are similar to <<SQL-Functions,SQL Functions>> but they apply to values.
 In Object-Oriented paradigm they are called "methods", as functions related to a type.

--- a/src/main/asciidoc/sql/SQL-Pagination.adoc
+++ b/src/main/asciidoc/sql/SQL-Pagination.adoc
@@ -1,7 +1,7 @@
 [discrete]
 === Pagination
 
-image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Pagination.md" float=right]
+image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Pagination.adoc" float=right]
 
 ArcadeDB supports pagination natively. Pagination doesn't consume server side resources because no cursors are used. Only <<RID,Record ID's>> are used as pointers to the physical position in the bucket.
 

--- a/src/main/asciidoc/sql/SQL-Profile.adoc
+++ b/src/main/asciidoc/sql/SQL-Profile.adoc
@@ -2,7 +2,7 @@
 
 === SQL - `PROFILE`
 
-image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Profile.md" float=right]
+image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Profile.adoc" float=right]
 
 PROFILE SQL command returns information about query execution planning and statistics for a specific statement.
 The statement is actually executed to provide the execution stats.

--- a/src/main/asciidoc/sql/SQL-Projections.adoc
+++ b/src/main/asciidoc/sql/SQL-Projections.adoc
@@ -2,7 +2,7 @@
 
 === Projections
 
-image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Projections.md" float=right]
+image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Projections.adoc" float=right]
 
 A projection is a value that is returned by a query statement (SELECT, MATCH).
 

--- a/src/main/asciidoc/sql/SQL-Rebuild-Index.adoc
+++ b/src/main/asciidoc/sql/SQL-Rebuild-Index.adoc
@@ -2,7 +2,7 @@
 
 === SQL - `REBUILD INDEX`
 
-image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Rebuild-Index.md" float=right]
+image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Rebuild-Index.adoc" float=right]
 
 Rebuilds automatic indexes.
 

--- a/src/main/asciidoc/sql/SQL-Select-Execution.adoc
+++ b/src/main/asciidoc/sql/SQL-Select-Execution.adoc
@@ -1,7 +1,7 @@
 [discrete]
 
 === SQL SELECT Statements Execution
-image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Select-Execution.md" float=right]
+image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Select-Execution.adoc" float=right]
 
 The execution flow of a SELECT statement is made of many steps.
 Understanding these steps will help you to write better and more optimized queries.

--- a/src/main/asciidoc/sql/SQL-Select.adoc
+++ b/src/main/asciidoc/sql/SQL-Select.adoc
@@ -2,7 +2,7 @@
 [discrete]
 === SQL - `SELECT`
 
-image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Select.md" float=right]
+image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Select.adoc" float=right]
 
 ArcadeDB supports the SQL language to execute queries against the database engine. For more information, see &lt;&lt;
 operators,SQL-Where.md#operators) and &lt;&lt;functions,SQL-Where.md#functions). For more information on the differences between this

--- a/src/main/asciidoc/sql/SQL-Traverse.adoc
+++ b/src/main/asciidoc/sql/SQL-Traverse.adoc
@@ -2,7 +2,7 @@
 
 === SQL - `TRAVERSE`
 
-image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Traverse.md" float=right]
+image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Traverse.adoc" float=right]
 
 Retrieves connected records crossing relationships. This works with both the Document and Graph API's, meaning that you can traverse relationships between say invoices and customers on a graph, without the need to model the domain using the Graph API.
 

--- a/src/main/asciidoc/sql/SQL-Truncate-Bucket.adoc
+++ b/src/main/asciidoc/sql/SQL-Truncate-Bucket.adoc
@@ -2,7 +2,7 @@
 
 === SQL - `TRUNCATE BUCKET`
 
-image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Truncate-Bucket.md" float=right]
+image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Truncate-Bucket.adoc" float=right]
 
 Deletes all records of a bucket. This command operates at a lower level than the standard <<SQL-Delete,`DELETE`>> command.
 

--- a/src/main/asciidoc/sql/SQL-Truncate-Type.adoc
+++ b/src/main/asciidoc/sql/SQL-Truncate-Type.adoc
@@ -2,7 +2,7 @@
 
 === SQL - `TRUNCATE TYPE`
 
-image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Truncate-Type.md" float=right]
+image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Truncate-Type.adoc" float=right]
 
 Deletes records of all buckets defined as part of the type. 
 

--- a/src/main/asciidoc/sql/SQL-Update.adoc
+++ b/src/main/asciidoc/sql/SQL-Update.adoc
@@ -1,7 +1,7 @@
 [discrete]
 === SQL - `UPDATE`
 
-image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Update.md" float=right]
+image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Update.adoc" float=right]
 
 Update one or more records in the current database. Remember: ArcadeDB can work in schema-less mode, so you can create any field on-the-fly. Furthermore, the command also supports extensions to work on collections.
 

--- a/src/main/asciidoc/sql/SQL-Where.adoc
+++ b/src/main/asciidoc/sql/SQL-Where.adoc
@@ -2,7 +2,7 @@
 [[Filtering]]
 === Filtering
 
-image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Where.md" float=right]
+image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Where.adoc" float=right]
 
 The Where condition is shared among many SQL commands.
 

--- a/src/main/asciidoc/sql/chapter.adoc
+++ b/src/main/asciidoc/sql/chapter.adoc
@@ -5,7 +5,7 @@
 [discrete]
 === Commands
 
-image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Commands.md" float=right]
+image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/chapter.adoc" float=right]
 
 [%header,cols=4]
 |===


### PR DESCRIPTION
Existing "Edit this Section" links in arcadedb-docs are broken, pointing to old markdown URLs that don't exist.

Updates the links to point to newer adoc urls.