### PR TITLE
fixes `keyTypes` type in createManualIndex documentation

### DIFF
--- a/src/main/asciidoc/api/java-schema.adoc
+++ b/src/main/asciidoc/api/java-schema.adoc
@@ -126,7 +126,7 @@ A special mention goes for the method `createManualIndex()` that creates indexes
 
 [source,java]
 ----
-Index createManualIndex(SchemaImpl.INDEX_TYPE indexType, boolean unique, String indexName, byte[] keyTypes, int pageSize);
+Index createManualIndex(SchemaImpl.INDEX_TYPE indexType, boolean unique, String indexName, com.arcadedb.schema.Type[] keyTypes, int pageSize);
 ----
 
 While by default indexes are updated automatically when you work with records, in this case, the user is totally responsible to insert and remove entries into and from the index.


### PR DESCRIPTION
updated `keyTypes` per:

https://github.com/ArcadeData/arcadedb/blob/27bbbaf78955ddc60bc905bb73cd17c586f17692/engine/src/main/java/com/arcadedb/schema/Schema.java#L77