### PR TITLE
Sec 8 (SQL) and Appendix fixes

### DIFF
--- a/src/main/asciidoc/appendix/settings.adoc
+++ b/src/main/asciidoc/appendix/settings.adoc
@@ -74,70 +74,70 @@ The table that follows contains all the available settings in ArcadeDB.
 [%header,cols="20%,55%,10%,15%",stripes=even]
 |===
 |Name|Description|Type|Default Value
-|asyncOperationsQueueImpl|Queue implementation to use between 'standard' and 'fast'. 'standard' consumes less CPU than the 'fast' implementation, but it could be slower with high loads|String|standard
-|asyncOperationsQueueSize|Size of the total asynchronous operation queues (it is divided by the number of parallel threads in the pool)|Integer|1024
-|asyncTxBatchSize|Maximum number of operations to commit in batch by async thread|Integer|10240
-|asyncWorkerThreads|Number of asynchronous worker threads. 0 (default) = available cores minus 1|Integer|15
-|bucketDefaultPageSize|Default page size in bytes for buckets. Default is 65536|Integer|65536
-|command.timeout|Default timeout for commands (in ms)|Long|0
-|commitLockTimeout|Timeout in ms to lock resources during commit|Long|5000
-|cypher.statementCache|Max number of entries in the cypher statement cache. Use 0 to disable. Caching statements speeds up execution of the same cypher queries|Integer|1000
-|dumpConfigAtStartup|Dumps the configuration at startup|Boolean|false
-|dumpMetricsEvery|Dumps the metrics at startup, shutdown and every configurable amount of time (in seconds)|Long|0
-|flushOnlyAtClose|Never flushes pages on disk until the database closing|Boolean|false
-|freePageRAM|Percentage (0-100) of memory to free when Page RAM is full|Integer|50
-|ha.clusterName|Cluster name. By default is 'arcadedb'. Useful in case of multiple clusters in the same network|String|arcadedb
-|ha.enabled|True if HA is enabled for the current server|Boolean|false
-|ha.k8s|The server is running inside Kubernetes|Boolean|false
-|ha.k8sSuffix|When running inside Kubernetes use this suffix to reach the other servers. Example: arcadedb.default.svc.cluster.local|String|
-|ha.quorum|Default quorum between 'none', 1, 2, 3, 'majority' and 'all' servers. Default is majority|String|MAJORITY
-|ha.quorumTimeout|Timeout waiting for the quorum|Long|10000
-|ha.replicationChunkMaxSize|Maximum channel chunk size for replicating messages between servers. Default is 16777216|Integer|16777216
-|ha.replicationFileMaxSize|Maximum file size for replicating messages between servers. Default is 1GB|Long|1073741824
-|ha.replicationIncomingHost|TCP/IP host name used for incoming replication connections. By default is 0.0.0.0 (listens to all the configured network interfaces)|String|0.0.0.0
-|ha.replicationIncomingPorts|TCP/IP port number used for incoming replication connections|String|2424-2433
-|ha.replicationQueueSize|Queue size for replicating messages between servers|Integer|512
-|ha.serverList|Servers in the cluster as a list of <hostname/ip-address:port> items separated by comma. Example: localhost:2424,192.168.0.1:2424|String|
-|indexCompactionMinPagesSchedule|Minimum number of mutable pages for an index to be schedule for automatic compaction. 0 = disabled|Integer|10
-|indexCompactionRAM|Maximum amount of RAM to use for index compaction, in MB|Long|300
-|initialPageCacheSize|Initial number of entries for page cache|Integer|65535
-|maxPageRAM|Maximum amount of pages (in MB) to keep in RAM|Long|4096
-|network.socketBufferSize|TCP/IP Socket buffer size, if 0 use the OS default|Integer|0
-|network.socketTimeout|TCP/IP Socket timeout (in ms)|Integer|30000
-|ssl.keyStore|Path where the SSL certificates are stored|String|null
-|ssl.keyStorePass|Password to open the SSL key store|String|null
-|ssl.trustStore|Path to the SSL trust store|String|null
-|ssl.trustStorePass|Password to open the SSL trust store|String|null
-|ssl.enabled|Use SSL for client connections|Boolean|false
-|pageFlushQueue|Size of the asynchronous page flush queue|Integer|512
-|postgres.debug|Enables the printing of Postgres protocol to the console. Default is false|Boolean|false
-|postgres.host|TCP/IP host name used for incoming connections for Postgres plugin. Default is '0.0.0.0'|String|0.0.0.0
-|postgres.port|TCP/IP port number used for incoming connections for Postgres plugin. Default is 5432|Integer|5432
-|profile|Specify the preferred profile among: default, high-performance, low-ram, low-cpu|String|default
-|queryMaxHeapElementsAllowedPerOp|Maximum number of elements (records) allowed in a single query for memory-intensive operations (eg. ORDER BY in heap). If exceeded, the query fails with an OCommandExecutionException. Negative number means no limit.This setting is intended as a safety measure against excessive resource consumption from a single query (eg. prevent OutOfMemory)|Long|500000
-|redis.host|TCP/IP host name used for incoming connections for Redis plugin. Default is '0.0.0.0'|String|0.0.0.0
-|redis.port|TCP/IP port number used for incoming connections for Redis plugin. Default is 6379|Integer|6379
-|server.databaseDirectory|Directory containing the database|String|${arcadedb.server.rootPath}/databases
-|server.databaseLoadAtStartup|Open all the available databases at server startup|Boolean|true
-|server.defaultDatabases|The default databases created when the server starts. The format is `(<database-name>[(<user-name>:<user-passwd>[:<user-group>])[,]*])[{import\|restore:<URL>}][;]*'. Pay attention on using `;` to separate databases and `,` to separate credentials. The supported actions are `import` and `restore`. Example: `Universe[elon:musk:admin];Amiga[Jay:Miner,Jack:Tramiel]{import:/tmp/movies.tgz}`|String|
-|server.httpIncomingHost|TCP/IP host name used for incoming HTTP connections|String|0.0.0.0
-|server.httpIncomingPort|TCP/IP port number used for incoming HTTP connections. Specify a single port or a range `<from-<to>`. Default is 2480-2489 to accept a range of ports in case they are occupied.|String|2480-2489
-|server.httpTxExpireTimeout|Timeout in seconds for a HTTP transaction to expire. This timeout is computed from the latest command against the transaction|Long|30
-|serverMetrics|True to enable metrics|Boolean|true
-|server.mode|Server mode between development, test and production|String|development
-|server.name|Server name|String|ArcadeDB_0
-|server.plugins|List of server plugins to install. The format to load a plugin is: `<pluginName>:<pluginFullClass>`|String|
-|server.rootPassword|Password for root user to use at first startup of the server. Set this to avoid asking the password to the user|String|null
-|server.rootPath|Root path in the file system where the server is looking for files. By default is the current directory|String|null
-|server.securityAlgorithm|Default encryption algorithm used for passwords hashing|String|PBKDF2WithHmacSHA256
-|server.securitySaltCacheSize|Cache size of hashed salt passwords. The cache works as LRU. Use 0 to disable the cache|Integer|64
-|server.saltIterations|Number of iterations to generate the salt or user password. Changing this setting does not affect stored passwords|Integer|65536
-|server.eventBusQueueSize|Size of the queue used as a buffer for unserviced database change events.|Integer|1000
-|sqlStatementCache|Maximum number of parsed statements to keep in cache|Integer|300
-|test|Tells if it is running in test mode. This enables the calling of callbacks for testing purpose |Boolean|false
-|txRetries|Number of retries in case of MVCC exception|Integer|3
-|txWAL|Uses the WAL|Boolean|true
-|txWalFlush|Flushes the WAL on disk at commit time. It can be 0 = no flush, 1 = flush without metadata and 2 = full flush (fsync)|Integer|0
-|typeDefaultBuckets|Default number of buckets to create per type|Integer|8
+|`asyncOperationsQueueImpl`|Queue implementation to use between 'standard' and 'fast'. 'standard' consumes less CPU than the 'fast' implementation, but it could be slower with high loads|String|standard
+|`asyncOperationsQueueSize`|Size of the total asynchronous operation queues (it is divided by the number of parallel threads in the pool)|Integer|1024
+|`asyncTxBatchSize`|Maximum number of operations to commit in batch by async thread|Integer|10240
+|`asyncWorkerThreads`|Number of asynchronous worker threads. 0 (default) = available cores minus 1|Integer|15
+|`bucketDefaultPageSize`|Default page size in bytes for buckets. Default is 65536|Integer|65536
+|`command.timeout`|Default timeout for commands (in ms)|Long|0
+|´commitLockTimeout`|Timeout in ms to lock resources during commit|Long|5000
+|`cypher.statementCache`|Max number of entries in the cypher statement cache. Use 0 to disable. Caching statements speeds up execution of the same cypher queries|Integer|1000
+|`dumpConfigAtStartup`|Dumps the configuration at startup|Boolean|false
+|`dumpMetricsEvery`|Dumps the metrics at startup, shutdown and every configurable amount of time (in seconds)|Long|0
+|`flushOnlyAtClose`|Never flushes pages on disk until the database closing|Boolean|false
+|`freePageRAM`|Percentage (0-100) of memory to free when Page RAM is full|Integer|50
+|`ha.clusterName`|Cluster name. By default is 'arcadedb'. Useful in case of multiple clusters in the same network|String|arcadedb
+|`ha.enabled`|True if HA is enabled for the current server|Boolean|false
+|`ha.k8s`|The server is running inside Kubernetes|Boolean|false
+|`ha.k8sSuffix`|When running inside Kubernetes use this suffix to reach the other servers. Example: `arcadedb.default.svc.cluster.local`|String|
+|`ha.quorum`|Default quorum between 'none', 1, 2, 3, 'majority' and 'all' servers. Default is majority|String|MAJORITY
+|`ha.quorumTimeout`|Timeout waiting for the quorum|Long|10000
+|`ha.replicationChunkMaxSize`|Maximum channel chunk size for replicating messages between servers. Default is 16777216|Integer|16777216
+|`ha.replicationFileMaxSize`|Maximum file size for replicating messages between servers. Default is 1GB|Long|1073741824
+|`ha.replicationIncomingHost`|TCP/IP host name used for incoming replication connections. By default is 0.0.0.0 (listens to all the configured network interfaces)|String|0.0.0.0
+|`ha.replicationIncomingPorts`|TCP/IP port number used for incoming replication connections|String|2424-2433
+|`ha.replicationQueueSize`|Queue size for replicating messages between servers|Integer|512
+|`ha.serverList`|Servers in the cluster as a list of <hostname/ip-address:port> items separated by comma. Example: `localhost:2424,192.168.0.1:2424`|String|
+|`indexCompactionMinPagesSchedule`|Minimum number of mutable pages for an index to be schedule for automatic compaction. 0 = disabled|Integer|10
+|`indexCompactionRAM`|Maximum amount of RAM to use for index compaction, in MB|Long|300
+|`initialPageCacheSize`|Initial number of entries for page cache|Integer|65535
+|`maxPageRAM`|Maximum amount of pages (in MB) to keep in RAM|Long|4096
+|`network.socketBufferSize`|TCP/IP Socket buffer size, if 0 use the OS default|Integer|0
+|`network.socketTimeout`|TCP/IP Socket timeout (in ms)|Integer|30000
+|`ssl.keyStore`|Path where the SSL certificates are stored|String|null
+|`ssl.keyStorePass`|Password to open the SSL key store|String|null
+|`ssl.trustStore`|Path to the SSL trust store|String|null
+|`ssl.trustStorePass`|Password to open the SSL trust store|String|null
+|`ssl.enabled`|Use SSL for client connections|Boolean|false
+|`pageFlushQueue`|Size of the asynchronous page flush queue|Integer|512
+|`postgres.debug`|Enables the printing of Postgres protocol to the console. Default is false|Boolean|false
+|`postgres.host`|TCP/IP host name used for incoming connections for Postgres plugin. Default is '0.0.0.0'|String|0.0.0.0
+|`postgres.port`|TCP/IP port number used for incoming connections for Postgres plugin. Default is 5432|Integer|5432
+|`profile`|Specify the preferred profile among: default, high-performance, low-ram, low-cpu|String|default
+|`queryMaxHeapElementsAllowedPerOp`|Maximum number of elements (records) allowed in a single query for memory-intensive operations (eg. ORDER BY in heap). If exceeded, the query fails with an OCommandExecutionException. Negative number means no limit.This setting is intended as a safety measure against excessive resource consumption from a single query (eg. prevent OutOfMemory)|Long|500000
+|`redis.host`|TCP/IP host name used for incoming connections for Redis plugin. Default is '0.0.0.0'|String|0.0.0.0
+|`redis.port`|TCP/IP port number used for incoming connections for Redis plugin. Default is 6379|Integer|6379
+|`server.databaseDirectory`|Directory containing the database|String|${arcadedb.server.rootPath}/databases
+|`server.databaseLoadAtStartup`|Open all the available databases at server startup|Boolean|true
+|`server.defaultDatabases`|The default databases created when the server starts. The format is `(<database-name>[(<user-name>:<user-passwd>[:<user-group>])[,]*])[{import\|restore:<URL>}][;]*'. Pay attention on using `;` to separate databases and `,` to separate credentials. The supported actions are `import` and `restore`. Example: `Universe[elon:musk:admin];Amiga[Jay:Miner,Jack:Tramiel]{import:/tmp/movies.tgz}`|String|
+|`server.httpIncomingHost`|TCP/IP host name used for incoming HTTP connections|String|0.0.0.0
+|`server.httpIncomingPort`|TCP/IP port number used for incoming HTTP connections. Specify a single port or a range `<from-<to>`. Default is 2480-2489 to accept a range of ports in case they are occupied.|String|2480-2489
+|`server.httpTxExpireTimeout`|Timeout in seconds for a HTTP transaction to expire. This timeout is computed from the latest command against the transaction|Long|30
+|`serverMetrics`|True to enable metrics|Boolean|true
+|`server.mode`|Server mode between development, test and production|String|development
+|`server.name`|Server name|String|ArcadeDB_0
+|`server.plugins`|List of server plugins to install. The format to load a plugin is: `<pluginName>:<pluginFullClass>`|String|
+|`server.rootPassword`|Password for root user to use at first startup of the server. Set this to avoid asking the password to the user|String|null
+|`server.rootPath`|Root path in the file system where the server is looking for files. By default is the current directory|String|null
+|`server.securityAlgorithm`|Default encryption algorithm used for passwords hashing|String|PBKDF2WithHmacSHA256
+|`server.securitySaltCacheSize`|Cache size of hashed salt passwords. The cache works as LRU. Use 0 to disable the cache|Integer|64
+|`server.saltIterations`|Number of iterations to generate the salt or user password. Changing this setting does not affect stored passwords|Integer|65536
+|`server.eventBusQueueSize`|Size of the queue used as a buffer for unserviced database change events.|Integer|1000
+|`sqlStatementCache`|Maximum number of parsed statements to keep in cache|Integer|300
+|`test`|Tells if it is running in test mode. This enables the calling of callbacks for testing purpose |Boolean|false
+|`txRetries`|Number of retries in case of MVCC exception|Integer|3
+|`txWAL`|Uses the WAL|Boolean|true
+|`txWalFlush`|Flushes the WAL on disk at commit time. It can be 0 = no flush, 1 = flush without metadata and 2 = full flush (fsync)|Integer|0
+|`typeDefaultBuckets`|Default number of buckets to create per type|Integer|8
 |===
 

--- a/src/main/asciidoc/appendix/sql-syntax.adoc
+++ b/src/main/asciidoc/appendix/sql-syntax.adoc
@@ -20,29 +20,32 @@ An identifier is a name that identifies an entity in ArcadeDB schema. Identifier
 - named parameters
 - variable names (LET)
 
-An identifier is a sequence of characters delimited by back-ticks ``` ` ```. 
+An identifier is a sequence of characters delimited by back-ticks `pass:c[`]`.
 Examples of valid identifiers are
-- ``` `surname` ```
-- ``` `name and surname` ```
-- ``` `foo.bar` ```
-- ``` `a + b` ```
-- ``` `select` ```
+
+- `pass:c[`surname`]`
+- `pass:c[`name and surname`]`
+- `pass:c[`foo.bar`]`
+- `pass:c[`a + b`]`
+- `pass:c[`select`]`
 
 The back-tick character can be used as a valid character for identifiers, but it has to be escaped with a backslash, eg.
-- ``` `foo \` bar` ```
+
+- `pass:c[`foo \` bar`]`
 
 The following are reserved identifiers, they can NEVER be used with a different meaning (upper or lower case):
 
-- ``` @rid ```: record ID
-- ``` @type ```: document type
+- `@rid`: record ID
+- `@type`: document type
 
 **Simplified identifiers**
 
 Identifiers that start with a letter or with `$` and that contain only numbers, letters and underscores, can be written without back-tick quoting. Reserved words cannot be used as simplified identifiers. Valid simplified identifiers are
-- ```name```
-- ```name_and_surname```
-- ```$foo```
-- ```name_12```
+
+- `name`
+- `name_and_surname`
+- `$foo`
+- `name_12`
 
 
 Examples of INVALID queries for wrong identifier syntax
@@ -145,6 +148,7 @@ In ArcadeDB SQL the following are reserved words
 **Base types **
 
 Accepted base types in ArcadeDB SQL are:
+
 - **integer numbers**: 
 
 Valid integers are
@@ -238,10 +242,11 @@ nUll
 **Numbers**
 
 ArcadeDB can store five different types of numbers
+
 - Integer: 32bit signed
 - Long: 64bit signed
 - Float: decimal 32bit signed
-- Duoble: decimal 64bit signed
+- Double: decimal 64bit signed
 - BigDecimal: absolute precision
 
 **Integers** are represented in SQL as plain numbers, eg. `123`. If the number represented exceeds the Integer maximum size (see Java java.lang.Integer `MAX_VALUE` and `MIN_VALUE`), then it's automatically converted to a Long. 
@@ -251,6 +256,7 @@ When an integer is saved to a schemaful property of another numerical type, it i
 **Longs** are represented in SQL as numbers with `L` suffix, eg. `123L` (L can be uppercase or lowercase). Plain numbers (withot L prefix) that exceed the Integer range are also automatically converted to Long. If the number represented exceeds the Long maximum size (see Java java.lang.Long `MAX_VALUE` and `MIN_VALUE`), then the result is `NULL`;
 
 Integer and Long numbers can be represented in base 10 (decimal), 8 (octal) or 16 (hexadecimal):
+
 - decimal: `["-"] ("0" | ( ("1"-"9") ("0"-"9")* ) ["l"|"L"]`, eg. 
   - `15`, `15L`  
   - `-164` 
@@ -311,6 +317,7 @@ The instantiation of BigDecimal can be done explicitly, using the `bigDecimal(<n
 **Mathematical operations**
 
 Mathematical Operations with numbers follow these rules:
+
 - Operations are calculated from left to right, following the operand priority. 
 - When an operation involves two numbers of different type, both are converted to the higher precision type between the two. 
 
@@ -335,6 +342,7 @@ The conversion of a number to BigDecimal can be done explicitly, using the `bigD
 **Collections**
 
 ArcadeDB supports two types of collections:
+
 - **Lists**: ordered, allow duplicates
 - **Sets**: not ordered (?), no duplicates
  
@@ -351,6 +359,7 @@ A `List` can be converted to a `Set` using the `.asSet()` method:
 
 [[SQL-Binary]]
 **Binary data**
+
 ArcadeDB can store binary data (byte arrays) in document fields. There is no native representation of binary data in SQL syntax, insert/update a binary field you have to use `decode(<base64string>, "base64")` function.
 
 To obtain the base64 string representation of a byte array, you can use the function `encode(<byteArray>, "base64")`
@@ -388,7 +397,8 @@ Valid expressions are:
 
 A modifier can be
 - a dot-separated field chain, eg. `foo.bar`. Dot notation is used to navigate relationships and document fields. eg.
-  ```
+
+```
   john = {
             name: "John",
             surname: "Jones",
@@ -400,7 +410,7 @@ A modifier can be
          }
             
   john.address.city.name = "London"
-  ```
+```
   
 - a method invocation, eg. `foo.size()`.
 

--- a/src/main/asciidoc/introduction/run.adoc
+++ b/src/main/asciidoc/introduction/run.adoc
@@ -36,4 +36,13 @@ You can spin up as many ArcadeDB servers you want to have a HA setup and scale u
 ArcadeDB uses a RAFT based election system to guarantee the consistency of the database.
 For more information look at <<#High-Availability,High Availability>>.
 
+[discrete]
+==== Binaries
+
+[%header,cols=3]
+|===
+|                     | **Linux** / **Mac** | **Windows**
+| <<Server,Server>>   | `bin/server.sh`     | `bin/server.bat`
+| <<Console,Console>> | `bin/console.sh`    | `bin/console.bat`
+|===
 

--- a/src/main/asciidoc/server/chapter.adoc
+++ b/src/main/asciidoc/server/chapter.adoc
@@ -1,4 +1,4 @@
-
+[[Server]]
 == Server
 
 include::server.adoc[]

--- a/src/main/asciidoc/sql/SQL-Functions.adoc
+++ b/src/main/asciidoc/sql/SQL-Functions.adoc
@@ -313,7 +313,7 @@ if(<expression>, <result-if-true>, <result-if-false>)
 
 Evaluates a condition (first parameters) and returns the second parameter if the condition is true, and the third parameter otherwise.
 
-*Examples*:
+*Examples*
 
 ----
 SELECT if(eval("name = 'John'"), "My name is John", "My name is not John") FROM Person
@@ -659,28 +659,36 @@ Where:
 SELECT shortestPath(#8:32, #8:10)
 ----
 
-*Examples* on finding the shortest path between vertices #8:32 and #8:10 only crossing outgoing edges
+*Examples*
+
+on finding the shortest path between vertices #8:32 and #8:10 only crossing outgoing edges
 
 [source,sql]
 ----
 SELECT shortestPath(#8:32, #8:10, 'OUT')
 ----
 
-*Examples* on finding the shortest path between vertices #8:32 and #8:10 only crossing incoming edges of type 'Friend'
+*Examples*
+
+on finding the shortest path between vertices #8:32 and #8:10 only crossing incoming edges of type 'Friend'
 
 [source,sql]
 ----
 SELECT shortestPath(#8:32, #8:10, 'IN', 'Friend')
 ----
 
-*Examples* on finding the shortest path between vertices #8:32 and #8:10 only crossing incoming edges of type 'Friend' or 'Colleague'
+*Examples*
+
+on finding the shortest path between vertices #8:32 and #8:10 only crossing incoming edges of type 'Friend' or 'Colleague'
 
 [source,sql]
 ----
 SELECT shortestPath(#8:32, #8:10, 'IN', ['Friend', 'Colleague'])
 ----
 
-*Examples* on finding the shortest path between vertices #8:32 and #8:10, long at most five hops
+*Examples*
+
+on finding the shortest path between vertices #8:32 and #8:10, long at most five hops
 
 [source,sql]
 ----

--- a/src/main/asciidoc/sql/SQL-Insert.adoc
+++ b/src/main/asciidoc/sql/SQL-Insert.adoc
@@ -26,7 +26,7 @@ INSERT INTO [TYPE:]<type>|BUCKET:<bucket>|INDEX:<index>
 * `@this` Returns the entire new record.
 * *`FROM`* Defines where you want to insert the result-set.
 
-*Examples*:
+*Examples*
 
 * Inserts a new record with the name `Jay` and surname `Miner`.
 

--- a/src/main/asciidoc/sql/SQL-Methods.adoc
+++ b/src/main/asciidoc/sql/SQL-Methods.adoc
@@ -420,7 +420,7 @@ SELECT salary.format("%-011d") FROM Employee
 ===== hash()
 
 Returns the hash of the field.
-Supports all the algorithms available in the JVM.
+Supports all the algorithms https://docs.oracle.com/en/java/javase/11/docs/specs/security/standard-names.html[available in the JVM].
 
 Syntax: `&lt;value&gt;`.hash([<algorithm>])```
 
@@ -481,6 +481,7 @@ Applies to the following types:
 - string
 
 *Examples*
+
 Returns all the UK numbers:
 
 [source,sql]
@@ -502,6 +503,7 @@ Applies to the following types:
 - any
 
 *Examples*
+
 Prints the Java type used to store dates:
 
 [source,sql]

--- a/src/main/asciidoc/sql/SQL-Select.adoc
+++ b/src/main/asciidoc/sql/SQL-Select.adoc
@@ -55,7 +55,7 @@ SELECT [ <Projections> ] [ FROM <Target> [ LET <Assignment>* ] ]
 ** `RETURN` Truncate the result-set, returning the data collected up to the timeout.
 ** `EXCEPTION` Raises an exception.
 
-*Examples*:
+*Examples*
 
 * Return all records of the type `Person`, where the name starts with `Luk`:
 [source,sql]

--- a/src/main/asciidoc/sql/SQL-Update.adoc
+++ b/src/main/asciidoc/sql/SQL-Update.adoc
@@ -37,7 +37,7 @@ UPDATE <type>|BUCKET:<bucket>|<recordID>
 
 NOTE: The <<RID,RID>> must have a `#` prefix. For instance, `#12:3`.
 
-*Examples*:
+*Examples*
 
 * Update to change the value of a field:
 

--- a/src/main/asciidoc/sql/SQL-Where.adoc
+++ b/src/main/asciidoc/sql/SQL-Where.adoc
@@ -37,10 +37,10 @@ And `item` can be:
 [%header,cols=3]
 |===
 |Name|Description|Example
-|@this|returns the record itself|select *@this.toJSON()* from Account
-|@rid|returns the <<RID,RID>> in the form &lt;bucket:position&gt;. It's null for embedded records. _NOTE: using @rid in where condition slow down queries. Much better to use the <<RID,RID>> as target. Example: change this: select from Profile where @rid = #10:44 with this: select from #10:44 _|__@rid** = #11:0
-|@size|returns the record size in bytes|**@size** &gt; 1024
-|@type|returns the record type between: 'document', 'column', 'flat', 'bytes'|**@type** = 'flat'
+|`@this`|returns the record itself|select *@this.toJSON()* from Account
+|`@rid`|returns the <<RID,RID>> in the form &lt;bucket:position&gt;. It's null for embedded records. _NOTE: using @rid in where condition slow down queries. Much better to use the <<RID,RID>> as target. Example: change this: select from Profile where @rid = #10:44 with this: select from #10:44 _|__@rid** = #11:0
+|`@size`|returns the record size in bytes|**@size** &gt; 1024
+|`@type`|returns the record type between: 'document', 'column', 'flat', 'bytes'|**@type** = 'flat'
 |===
 
 [discrete]
@@ -93,11 +93,11 @@ And `item` can be:
 [%header,cols=4]
 |===
 |Apply to|Operator|Description|Example
-|Numbers|+|Plus|age + 34
-|Numbers|-|Minus|salary - 34
-|Numbers|*|Multiply|factor * 1.3
-|Numbers|/|Divide|total / 12
-|Numbers|%|Mod|total % 3
+|Numbers|+|Plus|`age + 34`
+|Numbers|-|Minus|`salary - 34`
+|Numbers|*|Multiply|`factor * 1.3`
+|Numbers|/|Divide|`total / 12`
+|Numbers|%|Mod|`total % 3`
 |===
 
 [discrete]
@@ -115,12 +115,12 @@ ArcadeDB supports variables managed in the context of the command/query. By defa
 [%header,cols=3]
 |===
 |Name |Description |Command(s)
-|$parent|Get the parent context from a sub-query. Example: select from V let $type = ( traverse * from $parent.$current.children )|<<SQL-Select,SQL-Query>> and <<SQL-Traverse,SQL-Traverse>>
-|$current|Current record to use in sub-queries to refer from the parent's variable|<<SQL-Select,SQL-Query>> and <<SQL-Traverse,SQL-Traverse>>
-|$depth|The current depth of nesting|<<SQL-Traverse,SQL-Traverse>>
-|$path|The string representation of the current path. Example: `#6:0.in.#5:0#.out`. You can also display it with -&gt; select $path from (traverse * from V)|<<SQL-Traverse,SQL-Traverse>>
-|$stack|The List of operation in the stack. Use it to access to the history of the traversal|<<SQL-Traverse,SQL-Traverse>>|1.1.0|
-|$history|The set of all the records traversed as a Set&lt;ORID&gt;|<<SQL-Traverse,TRAVERSE>>
+|`$parent`|Get the parent context from a sub-query. Example: select from V let $type = ( traverse * from $parent.$current.children )|<<SQL-Select,SQL-Query>> and <<SQL-Traverse,SQL-Traverse>>
+|`$current`|Current record to use in sub-queries to refer from the parent's variable|<<SQL-Select,SQL-Query>> and <<SQL-Traverse,SQL-Traverse>>
+|`$depth`|The current depth of nesting|<<SQL-Traverse,SQL-Traverse>>
+|`$path`|The string representation of the current path. Example: `#6:0.in.#5:0#.out`. You can also display it with -&gt; select $path from (traverse * from V)|<<SQL-Traverse,SQL-Traverse>>
+|`$stack`|The List of operation in the stack. Use it to access to the history of the traversal|<<SQL-Traverse,SQL-Traverse>>|1.1.0|
+|`$history`|The set of all the records traversed as a Set&lt;ORID&gt;|<<SQL-Traverse,TRAVERSE>>
 |===
 
 To set custom variable use the <<SQL-LET,LET>> keyword.


### PR DESCRIPTION
* made subheadings, particularly **Examples** consistent in Sec. 8
* fixed more malformed lists
* added a link to a java docu listing hash algorithms
* formatted code in tables with literal monospace, ie variables, short code examples

---

* Added table listing binaries to Sec. 2