### PR TITLE
Add sqlscript as language option

### DIFF
--- a/src/main/asciidoc/api/http.adoc
+++ b/src/main/asciidoc/api/http.adoc
@@ -152,7 +152,7 @@ curl -X POST http://localhost:2480/api/v1/document/school
 [cols="30,10,~",options="header"]
 |===
 | *Parameters* | *Type*     | *Values*
-| language   | Required | "sql", "graphql", "cypher", "gremlin", "mongo", and others
+| language   | Required | "sql", "sqlscript", "graphql", "cypher", "gremlin", "mongo", and others
 | command    | Required | encoded command string
 | limit      | Optional | maximum number of results
 | params     | Optional | map of parameters
@@ -210,7 +210,7 @@ curl -X POST http://localhost:2480/api/v1/command/school
 
 The payload, as a JSON, accepts the following parameters:
 
-- `language` is the query language used, between "sql", "graphql", "cypher", "gremlin", "mongo" and any other language supported by ArcadeDB and available at runtime.
+- `language` is the query language used, between "sql", "sqlscript", "graphql", "cypher", "gremlin", "mongo" and any other language supported by ArcadeDB and available at runtime.
 - `command` the command to execute in encoded format
 - `limit` (optional) is the maximum number of results to return
 - `params` (optional), is the map of parameters to pass to the query engine
@@ -415,7 +415,7 @@ Where:
 
 - `database` is the database name
 - `language` is the query language used.
-is the query language used, between "sql", "graphql", "cypher", "gremlin", "mongo" and any other language supported by ArcadeDB and available at runtime.
+is the query language used, between "sql", "sqlscript", "graphql", "cypher", "gremlin", "mongo" and any other language supported by ArcadeDB and available at runtime.
 - `command` the command to execute in encoded format
 
 You might need to encode the URL if contains special characters and spaces.

--- a/src/main/asciidoc/tools/importer.adoc
+++ b/src/main/asciidoc/tools/importer.adoc
@@ -6,6 +6,8 @@ ArcadeDB provides some basic ETL capabilities for automatically importing datase
 
 - https://orientdb.org[OrientDB] database export
 - https://neo4j.com[Neo4j] database export
+- http://graphml.graphdrawing.org[GraphML] database export
+- https://github.com/tinkerpop/blueprints/wiki/GraphSON-Reader-and-Writer-Library[GraphSON] database export
 - Generic XML files
 - Generic JSON files
 - Generic CSV files


### PR DESCRIPTION
Checking the network requests of the studio I found out that "sqlscript" as used as value for the language key of the command endpoint POST request, thus I added this to the documentation in Section 7.4.