### PR TITLE
CHICKEN Scheme driver, typo, and HTTP example

### DIFF
--- a/src/main/asciidoc/api/chapter.adoc
+++ b/src/main/asciidoc/api/chapter.adoc
@@ -32,6 +32,7 @@ ArcadeDB provides <<HTTP-API,HTTP API>> to interface to the server from a remote
 |===
 | Language | Project URL | License
 | Java | Bundled with the project. Look at `Remote Database` class | Apache 2
+| CHICKEN Scheme | http://wiki.call-cc.org/eggref/5/arcadedb | zlib-acknowledgement
 | .NET | https://github.com/tetious/ArcadeDb.Client | Apache 2
 | Ruby | https://github.com/topofocus/arcadedb | MIT
 | RUST | https://crates.io/crates/arcadedb-rs | Apache 2

--- a/src/main/asciidoc/api/chapter.adoc
+++ b/src/main/asciidoc/api/chapter.adoc
@@ -28,7 +28,7 @@ ArcadeDB supports multiple languages, so it's easier to use it coming from other
 
 ArcadeDB provides <<HTTP-API,HTTP API>> to interface to the server from a remote application. You can use any programming language that supports HTTP calls (pretty much any language) or use a driver to have a little abstraction over <<HTTP-API,HTTP API>>.
 
-[%header,cols="20%,65%,15%"]
+[%header,cols="20%,60%,20%"]
 |===
 | Language | Project URL | License
 | Java | Bundled with the project. Look at `Remote Database` class | Apache 2

--- a/src/main/asciidoc/api/http.adoc
+++ b/src/main/asciidoc/api/http.adoc
@@ -177,7 +177,7 @@ Example:
 
 ```
 curl -X POST http://localhost:2480/api/v1/begin/school
-     --user root:arcadedb-password
+     --user root:arcadedb-password -I
 ```
 
 Returns the Session Id in the response header, example:

--- a/src/main/asciidoc/sql/SQL-Insert.adoc
+++ b/src/main/asciidoc/sql/SQL-Insert.adoc
@@ -73,7 +73,7 @@ ArcadeDB> INSERT INTO Profile BUCKET profile_recent SET name = 'Jay',
 * Insert several records at the same time:
 [source,sql]
 ----
-ArcadeDB> INSERT INTO Profile(name, surname) VALUES ('Jay', 'Miner'), 
+ArcadeDB> INSERT INTO Profile (name, surname) VALUES ('Jay', 'Miner'), 
             ('Frank', 'Hermier'), ('Emily', 'Sout')
 ----
 


### PR DESCRIPTION
* Added my **CHICKEN Scheme** to the driver table
* Fixed typo in SQL `INSERT INTO` example
* Added `-I` to `begin` HTTP API request example so session-ID is returned