### PR TITLE
`sqlscript` section, `CHECK DATABASE` fields, `set language` console command

### DIFF
--- a/src/main/asciidoc/api/http.adoc
+++ b/src/main/asciidoc/api/http.adoc
@@ -22,6 +22,16 @@ Use the session id in the request header of further commands you want to execute
 After a period of inactivity (default is 30 seconds), the server automatically rolls back and purges expired transactions.
 
 [discrete]
+==== Transaction Scripts
+
+In case <<SQL,SQL>> (`sql`) is supposed to be used as language for a transactions,
+the language variant "SQL script" (`sqlscript`) is available.
+A `sqlscript` can consist of one or multiple SQL statements,
+which are collectively treated as a transaction.
+Hence, for such a batch of SQL statements, no `begin` and `commit` commands are necessary,
+since `begin` and `commit` implicitly enclose any `sqlscript` command.
+
+[discrete]
 [[WebSocket-Streaming]]
 ==== Streaming Change Events
 

--- a/src/main/asciidoc/sql/SQL-Check-Database.adoc
+++ b/src/main/asciidoc/sql/SQL-Check-Database.adoc
@@ -24,7 +24,48 @@ CHECK DATABASE [ TYPE <type-name>[,]* ] [ BUCKET <bucket-name>[,]* ] [ FIX ]
 * *`&lt;bucket-name&gt;`* Optional, if specified limit the check (and the fix) only to the specific buckets
 * *`FIX`* Optional, if defined auto fix the issue found with the check
 
-The command returns the integrity check report in one record.
+The command returns the integrity check report in one record with the fields:
+
+[cols="1,1"]
+|===
+| `avgPageUsed` | average space used in a page.
+                  This is a percentage value, where 100% means all the pages are full.
+                  If a record is too big, a page is split into multiple pages and multiple reads are necessary.
+                  Sometimes it helps to create buckets with larger pages to accommodate large records,
+                  see the <<Settings,`bucketDefaultPageSize`>> setting.
+| `warnings` | set of warning messages. 
+| `totalSurrogateRecords` | number of records that have been moved between pages.
+                            This happens when a record is updated and doesn't fit the original page,
+                            so a surrogate (placeholder) is set to point to the new page/position or it's a piece of a record stored on multiple pages. Internal, can be ignored.
+| `totalPlaceholderRecords` | see above. Internal, can be ignored. 
+| `pageSize` | internal, can be ignored.
+| `totalDeletedRecords` | number of records deleted in the database.
+                          When a record is deleted, it's RID is not recycled!
+| `totalAllocatedRecords` | total number of records created in the database.
+                            A record can be of type document, vertex or edge.
+| `totalAllocatedVertices` | see above, but only vertex records.
+| `totalAllocatedEdges` | see above, but only edge records.
+| `totalActiveRecords` | total number of records that are "active" (not deleted).
+                         A record can be of type document, vertex or edge.
+| `totalActiveVertices` | see above, but only vertex records.
+| `totalActiveEdges` | see above, but only edge records.
+| `totalMaxOffset` | internal, can be ignored.
+| `deletedRecords` | number of deleted records in the database (allocated minus active).
+| `corruptedRecords` | all the records not found in the database.
+                       This could happen with broken edges (edges pointing to deleted vertices).
+                       This should be zero; if not, it means there is a bug in the graph operations that doesn't keep operations 100% transactional. Please report this.
+| `totalPages` | total number of pages in the database.
+| `rebuiltIndexes` | list of indexes that have been rebuilt automatically if corrupted records were found.
+| `operation` | can be ignored, set by the console.
+| `invalidLinks` | similar to corrupted records; should be zero.
+| `errors` | counter of errors encountered while checking the database.
+             It should be zero.
+| `autoFix` | counter of autofix operations executed by the check database under the hood when corrupted records have been encountered. 
+              Some operations, like broken edges, can be fixed and restored automatically.
+|===
+
+
+
 
 *Examples*
 

--- a/src/main/asciidoc/sql/SQL-Check-Database.adoc
+++ b/src/main/asciidoc/sql/SQL-Check-Database.adoc
@@ -26,8 +26,9 @@ CHECK DATABASE [ TYPE <type-name>[,]* ] [ BUCKET <bucket-name>[,]* ] [ FIX ]
 
 The command returns the integrity check report in one record with the fields:
 
-[cols="1,1"]
+[cols="1,3",options="header"]
 |===
+| *Field* | *Description*
 | `avgPageUsed` | average space used in a page.
                   This is a percentage value, where 100% means all the pages are full.
                   If a record is too big, a page is split into multiple pages and multiple reads are necessary.
@@ -63,9 +64,6 @@ The command returns the integrity check report in one record with the fields:
 | `autoFix` | counter of autofix operations executed by the check database under the hood when corrupted records have been encountered. 
               Some operations, like broken edges, can be fixed and restored automatically.
 |===
-
-
-
 
 *Examples*
 

--- a/src/main/asciidoc/sql/SQL-Check-Database.adoc
+++ b/src/main/asciidoc/sql/SQL-Check-Database.adoc
@@ -44,10 +44,12 @@ The command returns the integrity check report in one record with the fields:
                           When a record is deleted, it's RID is not recycled!
 | `totalAllocatedRecords` | total number of records created in the database.
                             A record can be of type document, vertex or edge.
+| `totalAllocatedDocuments` | see above, but only documents records.
 | `totalAllocatedVertices` | see above, but only vertex records.
 | `totalAllocatedEdges` | see above, but only edge records.
 | `totalActiveRecords` | total number of records that are "active" (not deleted).
                          A record can be of type document, vertex or edge.
+| `totalActiveDocuments` | see above, but only vertex document.                       
 | `totalActiveVertices` | see above, but only vertex records.
 | `totalActiveEdges` | see above, but only edge records.
 | `totalMaxOffset` | internal, can be ignored.
@@ -59,7 +61,7 @@ The command returns the integrity check report in one record with the fields:
 | `rebuiltIndexes` | list of indexes that have been rebuilt automatically if corrupted records were found.
 | `operation` | can be ignored, set by the console.
 | `invalidLinks` | similar to corrupted records; should be zero.
-| `errors` | counter of errors encountered while checking the database.
+| `totalErrors` | counter of errors encountered while checking the database.
              It should be zero.
 | `autoFix` | counter of autofix operations executed by the check database under the hood when corrupted records have been encountered. 
               Some operations, like broken edges, can be fixed and restored automatically.

--- a/src/main/asciidoc/sql/SQL-Check-Database.adoc
+++ b/src/main/asciidoc/sql/SQL-Check-Database.adoc
@@ -40,7 +40,7 @@ The command returns the integrity check report in one record with the fields:
                             so a surrogate (placeholder) is set to point to the new page/position or it's a piece of a record stored on multiple pages. Internal, can be ignored.
 | `totalPlaceholderRecords` | see above. Internal, can be ignored. 
 | `pageSize` | internal, can be ignored.
-| `totalDeletedRecords` | number of records deleted in the database.
+| `totalDeletedRecords` | number of records deleted in the database (allocated minus active).
                           When a record is deleted, it's RID is not recycled!
 | `totalAllocatedRecords` | total number of records created in the database.
                             A record can be of type document, vertex or edge.
@@ -51,7 +51,7 @@ The command returns the integrity check report in one record with the fields:
 | `totalActiveVertices` | see above, but only vertex records.
 | `totalActiveEdges` | see above, but only edge records.
 | `totalMaxOffset` | internal, can be ignored.
-| `deletedRecords` | number of deleted records in the database (allocated minus active).
+| `deletedRecordsAfterFix` | holds the list of RIDs deleted after a fix.
 | `corruptedRecords` | all the records not found in the database.
                        This could happen with broken edges (edges pointing to deleted vertices).
                        This should be zero; if not, it means there is a bug in the graph operations that doesn't keep operations 100% transactional. Please report this.

--- a/src/main/asciidoc/tools/console.adoc
+++ b/src/main/asciidoc/tools/console.adoc
@@ -26,6 +26,7 @@ commit                                                -> commits current transac
 connect <path>|remote:<url> <user> <password>         -> connects to a database
 info types                                            -> prints available types
 info transaction                                      -> prints current transaction
+set language = sql|sqlscript|cypher|gremlin|mongo     -> sets console query language
 rollback                                              -> rolls back current transaction
 quit or exit                                          -> exits from the console
 ----


### PR DESCRIPTION
* Added subsection on implicit transaction when using `sqlscript` to Sectipn 7.4
* Added table explaining returned fields from `CHECK DATABASE` SQL command
* Added `set language` command to console overview in Section 6.1

Please review https://github.com/ArcadeData/arcadedb-docs/issues/88#issuecomment-1338073497 before merging, as there are some fields in `CHECK DATABASE` that are still unclear.

Thank you

