### PR TITLE
server dependency in addition to engine

### DIFF
--- a/src/main/asciidoc/server/embed-server.adoc
+++ b/src/main/asciidoc/server/embed-server.adoc
@@ -11,7 +11,7 @@ If you're using Maven include this dependency in your `pom.xml` file.
 ```xml
 <dependency>
     <groupId>com.arcadedb</groupId>
-    <artifactId>arcadedb-engine</artifactId>
+    <artifactId>arcadedb-server</artifactId>
     <version>21.10.1</version>
 </dependency>
 ```


### PR DESCRIPTION
To run an embedded server the arcadedb-server dependency needs to be added.