### PR TITLE
increase the references to ArcadeDB versions consistently up to 23.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>com.arcadedb</groupId>
     <artifactId>arcadedb-doc</artifactId>
-    <version>21.9.1</version>
+    <version>23.1.1</version>
     <packaging>war</packaging>
 
     <properties>

--- a/src/main/asciidoc/api/graphql.adoc
+++ b/src/main/asciidoc/api/graphql.adoc
@@ -14,7 +14,7 @@ If you're using Maven include this dependency in your `pom.xml` file.
 <dependency>
     <groupId>com.arcadedb</groupId>
     <artifactId>arcadedb-graphql</artifactId>
-    <version>21.12.1</version>
+    <version>23.1.1</version>
 </dependency>
 ----
 

--- a/src/main/asciidoc/api/gremlin.adoc
+++ b/src/main/asciidoc/api/gremlin.adoc
@@ -14,7 +14,7 @@ If you're using Maven include this dependency in your `pom.xml` file.
 <dependency>
     <groupId>com.arcadedb</groupId>
     <artifactId>arcadedb-gremlin</artifactId>
-    <version>21.12.1</version>
+    <version>23.1.1</version>
 </dependency>
 ----
 

--- a/src/main/asciidoc/api/java-api.adoc
+++ b/src/main/asciidoc/api/java-api.adoc
@@ -10,7 +10,7 @@ Add the following dependency in your Maven pom.xml file under the tag `<dependen
 <dependency>
     <groupId>com.arcadedb</groupId>
     <artifactId>arcadedb-engine</artifactId>
-    <version>21.10.1</version>
+    <version>23.1.1</version>
 </dependency>
 ----
 

--- a/src/main/asciidoc/api/mongo.adoc
+++ b/src/main/asciidoc/api/mongo.adoc
@@ -13,7 +13,7 @@ If you're using Maven include this dependency in your `pom.xml` file.
 <dependency>
     <groupId>com.arcadedb</groupId>
     <artifactId>arcadedb-mongodbw</artifactId>
-    <version>21.10.1</version>
+    <version>23.1.1</version>
 </dependency>
 ----
 

--- a/src/main/asciidoc/api/postgres.adoc
+++ b/src/main/asciidoc/api/postgres.adoc
@@ -13,7 +13,7 @@ If you're using Maven include this dependency in your `pom.xml` file.
 <dependency>
     <groupId>com.arcadedb</groupId>
     <artifactId>arcadedb-postgresw</artifactId>
-    <version>21.10.1</version>
+    <version>23.1.1</version>
 </dependency>
 ----
 

--- a/src/main/asciidoc/api/redis.adoc
+++ b/src/main/asciidoc/api/redis.adoc
@@ -14,7 +14,7 @@ If you're using Maven include this dependency in your `pom.xml` file.
 <dependency>
     <groupId>com.arcadedb</groupId>
     <artifactId>arcadedb-redisw</artifactId>
-    <version>21.10.1</version>
+    <version>23.1.1</version>
 </dependency>
 ----
 

--- a/src/main/asciidoc/server/embed-server.adoc
+++ b/src/main/asciidoc/server/embed-server.adoc
@@ -12,7 +12,7 @@ If you're using Maven include this dependency in your `pom.xml` file.
 <dependency>
     <groupId>com.arcadedb</groupId>
     <artifactId>arcadedb-server</artifactId>
-    <version>21.10.1</version>
+    <version>23.1.1</version>
 </dependency>
 ```
 

--- a/src/main/asciidoc/version.adoc
+++ b/src/main/asciidoc/version.adoc
@@ -1,1 +1,1 @@
-:revnumber: 22.12.1
+:revnumber: 23.1.1


### PR DESCRIPTION
The mentioning of arcadedb versions were not consistent. Updated all to 23.1.1.