### PR TITLE
Remove quot marks from FORMAT argument of EXPORT DATABASE (SQL)

### DIFF
--- a/src/main/asciidoc/sql/SQL-Export-Database.adoc
+++ b/src/main/asciidoc/sql/SQL-Export-Database.adoc
@@ -10,15 +10,14 @@ Exports a database in the `exports` directory under the root directory where Arc
 
 [source,sql]
 ----
-EXPORT DATABASE <url> [FORMAT "JSONL"|"GRAPHML"|"GRAPHSON"] [OVERWRITE TRUE|FALSE]
+EXPORT DATABASE <url> [FORMAT JSONL|GRAPHML|GRAPHSON] [OVERWRITE TRUE|FALSE]
 
 ----
 
 * *`&lt;url&gt;`* Defines the location of the file to export. Use:
- ** `file://` as prefix for files located on the same file system where ArcadeDB is running. For security reasons, it is not
- possible to provide an absolute or relative path to the file
+ ** `file://` as prefix for files located on the same file system where ArcadeDB is running. For security reasons, it is not possible to provide an absolute or relative path to the file
 * *`&lt;FORMAT&gt;`* The format of the export as a quoted string
- ** *jsonl* exports in JSONL format (one json per line)
+ ** *JSONL* exports in JSONL format (one json per line)
  ** *GraphML* exports in the popular GraphML format. GraphML is supported by all the major Graph DBMS. This format does not support complex types, like collection of elements. Using GraphSON instead of GraphML is recommended
  ** *GraphSON* database export. GraphSON is supported by all the major Graph DBMS
 * *`&lt;OVERWRITE&gt;`* Overwrite the export file if exists. Default is false.
@@ -34,5 +33,5 @@ ArcadeDB> EXPORT DATABASE file://database.jsonl.tgz
 * Export the current database in GraphSON format, overwriting any existent file if present:
 
 ----
-ArcadeDB> EXPORT DATABASE file://Movies.graphson.tgz FORMAT 'GraphSON' OVERWRITE true
+ArcadeDB> EXPORT DATABASE file://Movies.graphson.tgz FORMAT GraphSON OVERWRITE true
 ----


### PR DESCRIPTION
* Removed quotation marks from arguments of `FORMAT` component of `EXPORT DATABASE` statement (SQL Section)