### PR TITLE
SQL Filtering Fixes (Section 8.3)

### DIFF
--- a/src/main/asciidoc/sql/SQL-Where.adoc
+++ b/src/main/asciidoc/sql/SQL-Where.adoc
@@ -56,23 +56,23 @@ And `item` can be:
 |Apply to|Operator|Description|Example
 |any|`=` or `==`|Equal to|name *=* 'Luke'
 |any|`+<=>+`|Null-safe equal to, is also true if left and right operands are `null`|name *+<=>+* word
-|string|like|Similar to equals, but allow the wildcards '%' that means 'any' and '?' that means 'any character'|name *like* 'Luk%'
+|string|LIKE|Similar to equals, but allows the wildcards '%' that means "any characters" and '?' that means "any single character". LIKE is case sensitive.|name _LIKE_ 'Luk%'
 |any|`&lt;`|Less than|age *&lt;* 40
 |any|`&lt;=`|Less or equal to|age *&lt;=* 40
 |any|`&gt;`|Greater than|age *&gt;* 40
 |any|`&gt;=`|Greater or equal to|age *&gt;=* 40
 |any|`&lt;&gt;` or `!=`|Not equal to|age *&lt;&gt;* 40
-|any|BETWEEN|The value is between a range. It's equivalent to &lt;field&gt; &gt;= &lt;from-value&gt; AND &lt;field&gt; &lt;= &lt;to-value&gt;|price BETWEEN 10 and 30
-|any|IS|Used to test if a value is NULL|children *is* null
-|record, string (as type name)|INSTANCEOF|Used to check if the record extends a type|@this *instanceof* 'Customer' or @type *instanceof* 'Provider'
-|collection|IN|contains any of the elements listed|name *in* ['European','Asiatic']
-|collection|CONTAINS|true if the collection contains at least one element that satisfy the next condition. Condition can be a single item: in this case the behaviour is like the IN operator|children *contains* (name = 'Luke') - map.values() *contains* (name = 'Luke')
-|collection|CONTAINSALL|true if all the elements of the collection satisfy the next condition|children _containsAll_ (name = 'Luke')
-|collection|CONTAINSANY|true if any the elements of the collection satisfy the next condition|children _containsAny_ (name = 'Luke')
-|map|CONTAINSKEY|true if the map contains at least one key equals to the requested. You can also use map.keys() CONTAINS in place of it|connections _containsKey_ 'Luke'
-|map|CONTAINSVALUE|true if the map contains at least one value equals to the requested. You can also use map.values() CONTAINS in place of it|connections _containsValue_ 10:3
-|string|CONTAINSTEXT| When used against an indexed field, a lookup in the index will be performed with the text specified as key. When there is no index a simple Java indexOf will be performed. So the result set could be different if you have an index or not on that field |text _containsText_ 'jay'
-|string|MATCHES|Matches the string using a http://www.regular-expressions.info/[Regular Expression]|text matches `\b[A-Z0-9.%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}\b`
+|any|BETWEEN|The value is between a range. It's equivalent to &lt;field&gt; &gt;= &lt;from-value&gt; AND &lt;field&gt; &lt;= &lt;to-value&gt;|price _BETWEEN_ 10 and 30
+|any|IS|Used to test if a value is NULL|children _IS_ null
+|record, string (as type name)|INSTANCEOF|Used to check if the record extends a type|@this _INSTANCEOF_ 'Customer' or @type _INSTANCEOF_ 'Provider'
+|collection|IN|contains any of the elements listed|name _IN_ ['European','Asiatic']
+|collection|CONTAINS|true if the collection contains at least one element that satisfy the next condition. Condition can be a single item: in this case the behaviour is like the IN operator|children _CONTAINS_ (name = 'Luke') - map.values() _CONTAINS_ (name = 'Luke')
+|collection|CONTAINSALL|true if all the elements of the collection satisfy the next condition|children _CONTAINSALL_ (name = 'Luke')
+|collection|CONTAINSANY|true if any the elements of the collection satisfy the next condition|children _CONTAINSANY_ (name = 'Luke')
+|map|CONTAINSKEY|true if the map contains at least one key equals to the requested. You can also use map.keys() CONTAINS in place of it|connections _CONTAINSKEY_ 'Luke'
+|map|CONTAINSVALUE|true if the map contains at least one value equals to the requested. You can also use map.values() CONTAINS in place of it|connections _CONTAINSVALUE_ 10:3
+|string|CONTAINSTEXT| When used against an indexed field, a lookup in the index will be performed with the text specified as key. When there is no index a simple Java indexOf will be performed. So the result set could be different if you have an index or not on that field |text _CONTAINSTEXT_ 'jay'
+|string|MATCHES|Matches the string using a http://www.regular-expressions.info/[Regular Expression]|text _MATCHES_ `\b[A-Z0-9.%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}\b`
 |===
 
 [discrete]


### PR DESCRIPTION
* Make case sensitivity of `LIKE` operator explicit
* Make examples in operator table consistent in formatting