### PR TITLE
Added `appendonly` group example

### DIFF
--- a/src/main/asciidoc/security/groups.adoc
+++ b/src/main/asciidoc/security/groups.adoc
@@ -90,6 +90,27 @@ The default settings for the `admin` group are:
 
 Which allows to execute any operation against the security, the schema and records.
 
+Here is an example for an append-only group:
+
+```json
+"appendonly": {
+  "access": [],
+  "resultSetLimit": -1,
+  "readTimeout": -1,
+  "types": {
+    "*": {
+      "access": [
+        "createRecord",
+        "readRecord"
+      ]
+    }
+  }
+}
+```
+
+Which allows the group members to read and create, but not to update or delete records.
+Such a group can be useful for ledgers, block chains, or data provenance.
+
 You can use any JSON editor to edit the file `config/server-groups.json`.
 It's recommended to keep a copy of the current file before editing the groups.
 In this way if there are any errors, it's easy to restore the previous file.


### PR DESCRIPTION
* Added `appendonly` group example to Security Section (Section 9)
* This may resolve [Append-only buckets](https://github.com/ArcadeData/arcadedb/issues/13)?