### PR TITLE
`backupDirectory` and `expand`

### DIFF
--- a/src/main/asciidoc/appendix/settings.adoc
+++ b/src/main/asciidoc/appendix/settings.adoc
@@ -91,7 +91,6 @@ If you're embedding a server in your Java application you can use these settings
 |`dumpConfigAtStartup`|Dumps the configuration at startup|Boolean|false
 |`dumpMetricsEvery`|Dumps the metrics at startup, shutdown and every configurable amount of time (in seconds)|Long|0
 |`profile`|Specify the preferred profile among: default, high-performance, low-ram, low-cpu|String|default
-|`server.databaseDirectory`|Directory containing the database|String|${arcadedb.server.rootPath}/databases
 |`test`|Tells if it is running in test mode. This enables the calling of callbacks for testing purpose |Boolean|false
 |===
 ===== SERVER
@@ -125,6 +124,8 @@ If you're embedding a server in your Java application you can use these settings
 |`mongo.host`|TCP/IP host name used for incoming connections for Mongo plugin. Default is '0.0.0.0'|String|0.0.0.0
 |`mongo.port`|TCP/IP port number used for incoming connections for Mongo plugin. Default is 27017|Integer|27017
 |`server.databaseLoadAtStartup`|Open all the available databases at server startup|Boolean|true
+|`server.databaseDirectory`|Directory containing the database|String|${arcadedb.server.rootPath}/databases
+|`server.backupDirectory`|Directory containing the backups|String|${arcadedb.server.rootPath}/backups
 |`server.defaultDatabases`|The default databases created when the server starts. The format is `(<database-name>[(<user-name>:<user-passwd>[:<user-group>])[,]*])[{import\|restore:<URL>}][;]*'. Pay attention on using `;` to separate databases and `,` to separate credentials. The supported actions are `import` and `restore`. Example: `Universe[elon:musk:admin];Amiga[Jay:Miner,Jack:Tramiel]{import:/tmp/movies.tgz}`|String|
 |`server.defaultDatabaseMode`|The default mode to load pre-existing databases. The value must match a com.arcadedb.engine.PaginatedFile.MODE enum value: {READ_ONLY, READ_WRITE}Databases which are newly created will always be opened READ_WRITE.|String|READ_WRITE
 |`server.httpsIncomingPort`|TCP/IP port number used for incoming HTTPS connections. Specify a single port or a range `<from>-<to>`. Default is 2490-2499 to accept a range of ports in case they are occupied.|String|2490-2499

--- a/src/main/asciidoc/sql/SQL-Functions.adoc
+++ b/src/main/asciidoc/sql/SQL-Functions.adoc
@@ -326,6 +326,9 @@ Syntax: `expand(&lt;field&gt;)`
 
 You can also use the SQL operator <<SQL-Select-Unwind,`UNWIND`>> in select to obtain the same result.
 
+NOTE: As `expand()` may change its return type based on the argument,
+      no modifiers (method calls, suffix identifiers or array indexing) are permitted on the return value of `expand()`. 
+
 *Examples*
 
 on collections:


### PR DESCRIPTION
* Added entry for `backupDirectory` setting in settings table (Section 11.2)
* Moved `databaseDirectory` setting to other `server.*` settings (Section 11.2)
* Added note to reference entry for special `expand()` function (Section 8.1)