### PR TITLE
HTTP and SQL Updates

### DIFF
--- a/src/main/asciidoc/api/http.adoc
+++ b/src/main/asciidoc/api/http.adoc
@@ -420,51 +420,6 @@ Example:
 ```
 
 [discrete]
-[[HTTP-OpenDatabase]]
-===== Open a database (POST)
-
-Opens a database on the server.
-By default, all the databases under the `databases/` directory on the server are loaded at startup.
-You can manually load the databases by setting `arcadedb.server.databaseLoadAtStartup=false` and invoking the open command on the databases you are going to use.
-Also, you can open a database previously closed because of a restore database command.
-
-URL Syntax: `/api/v1/open/{database}`
-
-Where:
-
-- `database` is the database name
-
-Example of opening the database "school":
-
-[source,shell]
-----
-curl -X POST http://localhost:2480/api/v1/open/school
-     --user root:arcadedb-password
-----
-
-[discrete]
-[[HTTP-CloseDatabase]]
-===== Close a database (POST)
-
-Closes a database on the server.
-Use this command to free resources in case there are many databases managed by the server.
-Also, close the database before a restore of the database.
-
-URL Syntax: `/api/v1/close/{database}`
-
-Where:
-
-- `database` is the database name
-
-Example of closing the database "school":
-
-[source,shell]
-----
-curl -X POST http://localhost:2480/api/v1/close/school
-     --user root:arcadedb-password
-----
-
-[discrete]
 [[HTTP-ExecuteQuery]]
 ===== Execute a query (GET)
 
@@ -483,6 +438,11 @@ You might need to encode the URL if contains special characters and spaces.
 
 NOTE: Due to security reasons (encoded) slashes `/` (`%2F`) which are used for divisions or block
       comments, cannot be used in queries via the `query/` endpoint.
+
+
+NOTE: Question marks (`?`) cause the server to stop reading the query string.
+      To use question marks (inside strings) one can use `format('%c',63)`;
+      in this case make sure to replace all percent symbols (`%`) in the format string with `%%`.
 
 Example:
 

--- a/src/main/asciidoc/appendix/sql-syntax.adoc
+++ b/src/main/asciidoc/appendix/sql-syntax.adoc
@@ -129,6 +129,7 @@ In ArcadeDB SQL the following are reserved words
 - EDGE
 - FETCHPLAN
 - FROM
+- ILIKE
 - INCREMENT
 - INSERT
 - INSTANCEOF
@@ -572,6 +573,7 @@ To add null values to a collection, you have to explicitly wrap them in another 
 - **`CONTAINSKEY`**: for maps, the same as for CONTAINS, but checks on the map keys
 - **`CONTAINSVALUE`**: for maps, the same as for CONTAINS, but checks on the map values
 - **`LIKE`**: for strings, checks if a string contains another string. `%` is used as a wildcard, eg. `'foobar CONTAINS '%ooba%''`
+- **`ILIKE`**: for strings, checks if a string contains another string disregarding case. `%` is used as a wildcard, eg. `'FOOBAR CONTAINS '%ooba%''`
 - **`IS DEFINED`** (unary): returns TRUE is a field is defined in a document
 - **`IS NOT DEFINED`** (unary): returns TRUE is a field is not defined in a document
 - **`BETWEEN - AND`** (ternary): returns TRUE is a value is between two values, eg. `5 BETWEEN 1 AND 10`

--- a/src/main/asciidoc/sql/SQL-Functions.adoc
+++ b/src/main/asciidoc/sql/SQL-Functions.adoc
@@ -618,11 +618,31 @@ Look http://download.oracle.com/javase/1.5.0/docs/api/java/util/Formatter.html#s
 
 Syntax: `format( &lt;format&gt; [,&lt;arg1&gt; ] [,&lt;arg-n&gt;]*)`
 
+NOTE: To escape the percent symbol (`%`) use `%%`.
+
 *Examples*
 
 [source,sql]
 ----
 SELECT format("%d - Mr. %s %s (%s)", id, name, surname, address) FROM Account
+----
+
+'''
+
+[discrete]
+
+===== concat()
+
+Aggregates field (or string) by implicitly casting to string and concatenate.
+Optionally a second field or string can be passed and is record-wise appended.
+
+Syntax: `concat( &lt;field|string&gt;[,&lt;field|string&gt;] )`
+
+*Examples*
+
+[source,sql]
+----
+SELECT concat(name) FROM names
 ----
 
 '''

--- a/src/main/asciidoc/sql/SQL-Methods.adoc
+++ b/src/main/asciidoc/sql/SQL-Methods.adoc
@@ -430,6 +430,13 @@ Example to exclude all the outgoing and incoming edges:
 SELECT EXPAND( @this.exclude( 'out_*', 'in_*' ) ) FROM V
 ----
 
+This function can be used to remove internal properties like `@rid`, `@type`, etc.
+
+[source,sql]
+----
+SELECT @this.exclude('@*') FROM doc
+----
+
 '''
 
 [discrete]

--- a/src/main/asciidoc/sql/SQL-Methods.adoc
+++ b/src/main/asciidoc/sql/SQL-Methods.adoc
@@ -780,6 +780,28 @@ SELECT FROM TreeItem WHERE children.size() > 0
 '''
 
 [discrete]
+===== split()
+
+Returns a list from a string separated by the provided delimiter.
+
+Syntax: `&lt;value&gt;.split(&lt;string&gt;)`
+
+Applies to the following types:
+
+- string
+
+*Examples*
+
+Returns string of comma separated values as list
+
+[source,sql]
+----
+SELECT 'a,b,c,d,e'.split(',')
+----
+
+'''
+
+[discrete]
 ===== subString()
 
 Returns a substring of the original cutting from 'begin' index up to 'end' index (not included).
@@ -807,6 +829,28 @@ SELECT "ArcadeDB".substring(0,6)
 ----
 
 returns `Orient`
+
+'''
+
+[discrete]
+===== transform()
+
+Returns the underlying collection to which one or more methods (passed as string arguments) are applied element-wise.
+
+Syntax: `&lt;value&gt;.transform(&lt;string&gt;[,&lt;string&gt;]*)`
+
+Applies to the following types:
+
+- collection
+
+NOTE: The argument methods cannot take arguments themselves.
+
+*Examples*
+
+[source,sql]
+----
+SELECT FROM Car WHERE options.transform( 'trim', 'toLowercase' ) CONTAINSALL ['a/c', 'airbags']
+----
 
 '''
 

--- a/src/main/asciidoc/sql/SQL-Where.adoc
+++ b/src/main/asciidoc/sql/SQL-Where.adoc
@@ -56,7 +56,7 @@ And `item` can be:
 |any|`=` or `==`|Equal to|name *=* 'Luke'
 |any|`+<=>+`|Null-safe equal to, is also true if left and right operands are `null`|name *+<=>+* word
 |string|LIKE|Similar to equals, but allows the wildcards '%' that means "any characters" and '?' that means "any single character". LIKE is case sensitive.|name _LIKE_ 'Luk%'
-|string|ILIKE|Similar to LIKE, but ILIKE is case insensitive.|name _LIKE_ 'Luk%'
+|string|ILIKE|Similar to LIKE, but ILIKE is case insensitive.|name _ILIKE_ 'lUk%'
 |any|`&lt;`|Less than|age *&lt;* 40
 |any|`&lt;=`|Less or equal to|age *&lt;=* 40
 |any|`&gt;`|Greater than|age *&gt;* 40

--- a/src/main/asciidoc/sql/SQL-Where.adoc
+++ b/src/main/asciidoc/sql/SQL-Where.adoc
@@ -56,6 +56,7 @@ And `item` can be:
 |any|`=` or `==`|Equal to|name *=* 'Luke'
 |any|`+<=>+`|Null-safe equal to, is also true if left and right operands are `null`|name *+<=>+* word
 |string|LIKE|Similar to equals, but allows the wildcards '%' that means "any characters" and '?' that means "any single character". LIKE is case sensitive.|name _LIKE_ 'Luk%'
+|string|ILIKE|Similar to LIKE, but ILIKE is case insensitive.|name _LIKE_ 'Luk%'
 |any|`&lt;`|Less than|age *&lt;* 40
 |any|`&lt;=`|Less or equal to|age *&lt;=* 40
 |any|`&gt;`|Greater than|age *&gt;* 40

--- a/src/main/asciidoc/sql/chapter.adoc
+++ b/src/main/asciidoc/sql/chapter.adoc
@@ -30,16 +30,16 @@ image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/
 | <<_in,in()>>       | <<_min,min()>> | <<_map,map()>> | <<_circle,circle()>> | <<_sysdate,sysdate()>>
 | <<_both,both()>>   | <<_max,max()>> | <<_list,list()>> | <<_rectangle,rectangle()>> | <<_format,format()>>
 | <<_oute,outE()>>   | <<_sum,sum()>> | <<_first,first()>> | <<_linestring,lineString()>> | <<_strcmpci,strcmpci()>>
-| <<_ine,inE()>>     | <<_avg,avg()>> | <<_last,last()>> | <<_polygon,polygon()>> | <<_if,if()>>
-| <<_bothe,bothE()>> | <<_sqrt,sqrt()>> | <<_intersect,intersect()>> |   | <<_ifnull-function,ifnull()>>
-| <<_outv,outV()>>   | <<_abs,abs()>> | <<_unionall,unionall()>> |    | <<_coalesce,coalesce()>>
-| <<_inv,inV()>>     | <<_variance,variance()>> | <<_distinct,distinct()>> |     | <<_uuid,uuid()>>
-| <<_bothv,bothV()>> | <<_stddev,stddev()>> | <<_difference,difference()>> |     | <<_encode,encode()>>
-| <<_traversedelement,traversedElement()>> | <<_mode,mode()>> | <<symmetricDifference,symmetricDifference()>> |      | <<_decode,decode()>>
-| <<_traversedvertex,traversedVertex()>> | <<_median,median()>> |   |   | <<_bool_and,bool_and()>>
-| <<_traversededge,traversedEdge()>> | <<_decimal,decimal()>> |  |  | <<_bool_or,bool_or()>>
-| <<_shortestpath,shortestPath()>> | <<_percentile,percentile()>> | |  | <<_expand,expand()>>
-| <<_dijkstra,dijkstra()>> | <<_distance,distance()>> | | |
+| <<_ine,inE()>>     | <<_avg,avg()>> | <<_last,last()>> | <<_polygon,polygon()>> | <<_concat,concat()>>
+| <<_bothe,bothE()>> | <<_sqrt,sqrt()>> | <<_intersect,intersect()>> |   | <<_if,if()>>
+| <<_outv,outV()>>   | <<_abs,abs()>> | <<_unionall,unionall()>> |    | <<_ifnull-function,ifnull()>>
+| <<_inv,inV()>>     | <<_variance,variance()>> | <<_distinct,distinct()>> |     | <<_coalesce,coalesce()>>
+| <<_bothv,bothV()>> | <<_stddev,stddev()>> | <<_difference,difference()>> |     | <<_uuid,uuid()>>
+| <<_traversedelement,traversedElement()>> | <<_mode,mode()>> | <<symmetricDifference,symmetricDifference()>> |      | <<_encode,encode()>>
+| <<_traversedvertex,traversedVertex()>> | <<_median,median()>> |   |   | <<_decode,decode()>>
+| <<_traversededge,traversedEdge()>> | <<_decimal,decimal()>> |  |  | <<_bool_and,bool_and()>>
+| <<_shortestpath,shortestPath()>> | <<_percentile,percentile()>> | |  | <<_bool_or,bool_or()>>
+| <<_dijkstra,dijkstra()>> | <<_distance,distance()>> | | | <<_expand,expand()>>
 | <<_astar,astar()>> | | | |
 |===
 
@@ -55,12 +55,13 @@ image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/
 |<<_asdecimal,asDecimal()>>|<<_right,right()>>|<<_keys,keys()>>| |<<_tojson,toJSON()>>
 |<<_asfloat,asFloat()>>|<<_prefix,prefix()>>|<<_values,values()>>| |<<_hash,hash()>>
 |<<_asinteger,asInteger()>>|<<_trim,trim()>>| | |<<_ifnull-method,ifnull()>>
-|<<_aslist,asList()>>|<<_replace,replace()>>| | |
+|<<_aslist,asList()>>|<<_replace,replace()>>| | |<<_transform,transform()>>
 |<<_aslong,asLong()>>|<<_length,length()>>| | |
 |<<_asmap,asMap()>>|<<_substring,subString()>>| | |  
 |<<_asrid,asRID()>>|<<_tolowercase,toLowerCase()>>| | |  
 |<<_asset,asSet()>>|<<_touppercase,toUpperCase()>>| | | 
 |<<_asstring,asString()>>|<<_normalize,normalize()>>| | |
+| |<<_split,split()>>| | |
 |===
 
 include::SQL-Introduction.adoc[]


### PR DESCRIPTION
* Remove leftover `open` and `close` endpoint HTTP-API reference entries (Section 7.5)
* Add note on `query` endpoint regarding question marks
* Add new functions and methods to SQL overview tables (Section 8)
* Add note on escaping percent symbols in `format function` in SQL function reference (Section 8.1)
* Add `concat` function to SQL function reference (Section 8.1)
* Add example to `exclude` function to SQL function reference (Section 8.1)
* Add `split` and `transform` methods to SQL method reference (Section 8.2)
* Add `ILIKE` to SQL filtering operators table (Section 8.3)
* Add `ILIKE` to SQL syntax appendix (Section 11.5)