### PR TITLE
Keeping Docs in Step with new Models

### DIFF
--- a/src/main/asciidoc/api/cypher.adoc
+++ b/src/main/asciidoc/api/cypher.adoc
@@ -19,7 +19,7 @@ The difference is larger with complex queries that work on many records.
 A simple Cypher MATCH with a lookup with a simple condition will be closer to native SQL performance, but a scan or huge traversal will be much slower with Cypher, because of the underlying usage of Gremlin is not optimized for extreme performance.
 
 [discrete]
-====== Cypher from Java API
+==== Cypher from Java API
 
 In order to execute a Cypher query, you need to include the relevant jars in your class path.
 To execute a Cypher query, use "cypher" as first parameter in the query method.
@@ -40,7 +40,7 @@ MATCH (m:Movie)<-[a:ACTED_IN]-(p:Person) WHERE id(m) = '#1:0' RETURN *
 ----
 
 [discrete]
-====== Cypher through Postgres Driver
+==== Cypher through Postgres Driver
 
 You can execute a Cypher query against ArcadeDB server by using the <<Postgres-Driver,Postgres driver>> and prefixing the query with `{cypher}`.
 Example:
@@ -53,7 +53,7 @@ Example:
 ArcadeDB server will execute the query `MATCH (p:Person) WHERE p.age >= 25 RETURN p.name, p.age ORDER BY p.age` using the Cypher query language.
 
 [discrete]
-====== Cypher through HTTP/JSON
+==== Cypher through HTTP/JSON
 
 You can execute a Cypher query against ArcadeDB server by using <<HTTP-API,HTTP/JSON>> API.
 Example of executing an idempotent query with HTTP GET command:
@@ -69,6 +69,8 @@ Example of executing a non-idempotent query (updates the database):
 ----
 curl -X POST "http://localhost:2480/command/graph" -d "{'language': 'cypher', 'command': 'MATCH (p:Person) WHERE p.age >= 25 RETURN p.name, p.age ORDER BY p.age'}"
 ----
+
+---
 
 For more information about Cypher:
 

--- a/src/main/asciidoc/content.adoc
+++ b/src/main/asciidoc/content.adoc
@@ -8,7 +8,9 @@ Skip the boring parts and check this out:
 ** <<Graph-Model,Graph>> (compatible with Gremlin and OrientDB SQL)
 ** <<Document-Model,Document>> (compatible with the MongoDB driver and MongoDB queries)
 ** <<KeyValue-Model,Key/Value>> (compatible with the Redis driver)
-** <<TimeSeries-Model,Time Series>>
+** <<SearchEngine-Model,Search Engine>>
+** <<TimeSeries-Model,Time Series>> (under construction)
+** <<VectorEmbedding-Model,Vector Embedding>> (under construction)
 
 * ArcadeDB understands multiple languages:
 ** <<SQL,SQL>> (inspired from OrientDB SQL dialect that supports pattern matching on graphs)

--- a/src/main/asciidoc/introduction/multimodel.adoc
+++ b/src/main/asciidoc/introduction/multimodel.adoc
@@ -2,7 +2,7 @@
 === Multi Model
 image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/introduction/multimodel.adoc" float="right"]
 
-The ArcadeDB engine supports **Graph**, **Document**, **Key/Value**, and **Time-Series** models, so you can use ArcadeDB as a replacement for a product in any of these categories. However, the main reason why users choose ArcadeDB is because of its true **Multi-Model** DBMS abilities, which combine all the features of the four models into the core. These abilities are not just interfaces to the database engine, but rather the engine itself was built to support all four models. This is also the main difference to other multi-model DBMSs, as they implement an additional layer with an API, which mimics additional models. However, under the hood, they're truly only one model, therefore they are limited in speed and scalability.
+The ArcadeDB engine supports **Graph**, **Document**, **Key/Value**, **Search-Engine**, **Time-Series** (🚧), and **Vector-Embedding** (🚧) models, so you can use ArcadeDB as a replacement for a product in any of these categories. However, the main reason why users choose ArcadeDB is because of its true **Multi-Model** DBMS abilities, which combine all the features of the four models into the core. These abilities are not just interfaces to the database engine, but rather the engine itself was built to support all four models. This is also the main difference to other multi-model DBMSs, as they implement an additional layer with an API, which mimics additional models. However, under the hood, they're truly only one model, therefore they are limited in speed and scalability.
 
 image::https://arcadedb.com/assets/images/multi-model-small.png[align="center"]
 
@@ -74,12 +74,18 @@ The table below illustrates the comparison between the relational model, the Key
 | Relationship     | not available    | <<Relationships,Relationship>>
 |===
 
+[[SearchEngine-Model]]
+==== Search-Engine Model
 
+Coming Soon.
 
 [[TimeSeries-Model]]
 ==== Time-Series Model
 
-Coming Soon.
+https://github.com/ArcadeData/arcadedb/discussions/469[Coming Soon].
 
+[[VectorEmbedding-Model]]
+==== Vector-Embedding Model
 
+https://github.com/ArcadeData/arcadedb/discussions/995[Coming Soon].
 

--- a/src/main/asciidoc/sql/SQL-Introduction.adoc
+++ b/src/main/asciidoc/sql/SQL-Introduction.adoc
@@ -86,6 +86,7 @@ alternatively, order a book such as:
 * or any of https://www.amazon.com/s/ref=nb_sb_noss/189-0251150-4407173?url=search-alias%3Daps&field-keywords=sql[these].
 
 For details on ArcadeDB's dialect, see <<SQL-Syntax,ArcadeDB SQL Syntax>>.
+You can also download a https://github.com/ArcadeData/arcadedb/files/11288907/arcadedb-sql.pdf[SQL Command Cheat Sheet] (pdf).
 
 *No JOINs*
 The most important difference between ArcadeDB and a Relational Database is that relationships are represented by `LINKS` instead of

--- a/src/main/asciidoc/sql/SQL-Traverse.adoc
+++ b/src/main/asciidoc/sql/SQL-Traverse.adoc
@@ -21,7 +21,7 @@ TRAVERSE [<type.]field>|*|any()|all()
            WHILE <condition> 
          ]
          [LIMIT <max-records>]
-         [STRATEGY <strategy>]
+         [STRATEGY DEPTH_FIRST|BREADTH_FIRST]
 
 ----
 
@@ -46,7 +46,7 @@ In a social network-like domain, a user profile is connected to friend through l
 ArcadeDB> TRAVERSE * FROM #10:1234
 ----
 
-* Specify fields and depth up to the third level, using the <<Traversal-Strategies,`BREADTH_FIRST`>> strategy:
+* Specify fields and depth up to the third level, using the <<_traversal-strategies,`BREADTH_FIRST`>> strategy:
 
 ----
 ArcadeDB> TRAVERSE out("Friend") FROM #10:1234 MAXDEPTH 3 
@@ -169,3 +169,15 @@ ArcadeDB> SELECT FROM (TRAVERSE outE(), inV() FROM (SELECT FROM User WHERE
           (@type = 'SentMessage' AND sentOn = '01/01/2012') )) WHERE 
           @type = 'Message'
 ----
+
+[discrete]
+==== Traversal Strategies
+
+When ArcadeDB traverses a graph it can use one of two available approaches,
+either explore every branch to its leaf before backtracking (depth-first),
+or visiting each child before progressing down the next level (breadth-first), see:
+
+* https://en.wikipedia.org/wiki/Depth-first_search[`DEPTH_FIRST` Strategy]
+* https://en.wikipedia.org/wiki/Breadth-first_search[`BREADTH_FIRST` Strategy]
+
+By default, the depth-first strategy is used.

--- a/src/main/asciidoc/sql/chapter.adoc
+++ b/src/main/asciidoc/sql/chapter.adoc
@@ -8,14 +8,14 @@ image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/
 [%header,cols=3]
 |===
 | CRUD & Graph | Schema & Buckets | Database & Indexes
-| <<SQL-Select,SELECT>> | <<SQL-Create-Type,CREATE TYPE>> | <<Console,CREATE DATABASE (_console only_)>>
-| <<SQL-Insert,INSERT>> | <<SQL-Alter-Type,ALTER TYPE>> | <<SQL-Alter-Database,ALTER DATABASE>>
-| <<SQL-Update,UPDATE>> | <<SQL-Drop-Type,DROP TYPE>> | <<Console,DROP DATABASE (_console only_)>>
-| <<SQL-Delete,DELETE>> | <<SQL-Truncate-Type,TRUNCATE TYPE>> | <<SQL-Backup-Database,BACKUP DATABASE>>
-| <<SQL-Create-Vertex,CREATE VERTEX>> | <<SQL-Create-Bucket,CREATE BUCKET>> | <<SQL-Import-Database,IMPORT DATABASE>>
-| <<SQL-Create-Edge,CREATE EDGE>> | ALTER BUCKET (_not implemented_) | <<_sql-export-database,EXPORT DATABASE>>
-| <<SQL-Match,MATCH>> | <<SQL-Drop-Bucket,DROP BUCKET>> | <<_sql-check-database,CHECK DATABASE>>
-| <<SQL-Traverse,TRAVERSE>> | <<SQL-Truncate-Bucket,TRUNCATE BUCKET>> | <<_sql-align-database,ALIGN DATABASE>>
+| <<SQL-Select,SELECT>> | <<SQL-Create-Type,CREATE TYPE>> | <<SQL-Alter-Database,ALTER DATABASE>>
+| <<SQL-Insert,INSERT>> | <<SQL-Alter-Type,ALTER TYPE>> | <<SQL-Backup-Database,BACKUP DATABASE>>
+| <<SQL-Update,UPDATE>> | <<SQL-Drop-Type,DROP TYPE>> | <<_sql-export-database,EXPORT DATABASE>>
+| <<SQL-Delete,DELETE>> | <<SQL-Truncate-Type,TRUNCATE TYPE>> | <<SQL-Import-Database,IMPORT DATABASE>>
+| <<SQL-Create-Vertex,CREATE VERTEX>> | <<SQL-Create-Bucket,CREATE BUCKET>> | <<_sql-align-database,ALIGN DATABASE>>
+| <<SQL-Create-Edge,CREATE EDGE>> | ALTER BUCKET (_not implemented_) | <<_sql-check-database,CHECK DATABASE>>
+| <<SQL-Match,MATCH>> | <<SQL-Drop-Bucket,DROP BUCKET>> |
+| <<SQL-Traverse,TRAVERSE>> | <<SQL-Truncate-Bucket,TRUNCATE BUCKET>> |
 | *Planning* | <<SQL-Create-Property,CREATE PROPERTY>> | <<SQL-Create-Index,CREATE INDEX>>
 | <<SQL-Explain,EXPLAIN>> | <<SQL-Alter-Property,ALTER PROPERTY>> | <<_sql-rebuild-index,REBUILD INDEX>>
 | <<SQL-Profile,PROFILE>> | <<SQL-Drop-Property,DROP PROPERTY>> | <<SQL-Drop-Index,DROP INDEX>>


### PR DESCRIPTION
* Added new models to Multimodel Section introduction (Section 2.2)
* Added stub sections for new models (Section 2.2)
* Add links to github issues in coming soon sections (Time-Series and Vector-Embedding)
* Add links to new models in Section 1
* Fix heading hierarchy in Cypher API section (Section 7.8)
* Add link to (updated) SQL cheat sheet to SQL Introduction section (Section 8)
* Add section on traversal strategies to Traverse command reference entry (Section 8.4)