### PR TITLE
Minor Fixes in SQL `CREATE PROPERTY` and clean up in console section

### DIFF
--- a/src/main/asciidoc/sql/SQL-Create-Property.adoc
+++ b/src/main/asciidoc/sql/SQL-Create-Property.adoc
@@ -17,9 +17,8 @@ CREATE PROPERTY
 
 * *`&lt;type&gt;`* Defines the type for the new property.
 * *`&lt;property&gt;`* Defines the logical name for the property.
-* *`&lt;data-type&gt;`* Defines the property data type.
+* *`&lt;data-type&gt;`* Defines the property data type. For supported types, see the table below.
 * *`&lt;embd-type&gt;`* Defines the property's embedded type (only for embedding property types `EMBEDDED`, `LIST`, `MAP`, as well as `LINK`).
-For supported types, see the table below.
 * *`&lt;property-constraint&gt;`* See <<SQL-Alter-Property,`ALTER PROPERTY`>> `&lt;attribute-name&gt; * &lt;attribute-value&gt;`
 ** `mandatory &lt;true|false&gt;` If true, the property must be present.
 Default is false

--- a/src/main/asciidoc/tools/console.adoc
+++ b/src/main/asciidoc/tools/console.adoc
@@ -18,39 +18,42 @@ The console supports the following commands (you can always retrieve this help b
 
 [source]
 ----
-begin                                             -> begins a new transaction
-check database                                    -> check database integrity
-close |<path>|remote:<url> <user> <pw>            -> closes the database
-commit                                            -> commits current transaction
+begin                                                          -> begins a new transaction
+check database                                                 -> check database integrity
+close |<path>|remote:<url> <user> <pw>                         -> closes the database
+commit                                                         -> commits current transaction
 connect <path>|local:<url>|remote:<url> <user> <pw>            -> connects to a database
-create database <path>|remote:<url> <user> <pw>   -> creates a new database
+create database <path>|remote:<url> <user> <pw>                -> creates a new database
 create user <user> identified by <pw> [grant connect to <db>*] -> creates a user
-drop database <path>|remote:<url> <user> <pw>     -> deletes a database
-drop user <user>                                  -> deletes a user
-help|?                                            -> ask for this help
-info types                                        -> prints available types
-info type <type>                                  -> prints details about type
-info transaction                                  -> prints current transaction
-list databases |remote:<url> <user> <pw>          -> lists databases
-load <path>                                       -> runs local script
-rollback                                          -> rolls back current transaction
-set language = sql|sqlscript|cypher|gremlin|mongo -> sets console query language
--- <comment>                                      -> comment (no operation)
-quit|exit                                         -> exits from the console
+drop database <path>|remote:<url> <user> <pw>                  -> deletes a database
+drop user <user>                                               -> deletes a user
+help|?                                                         -> ask for this help
+info types                                                     -> prints available types
+info type <type>                                               -> prints details about type
+info transaction                                               -> prints current transaction
+list databases |remote:<url> <user> <pw>                       -> lists databases
+load <path>                                                    -> runs local script
+rollback                                                       -> rolls back current transaction
+set language = sql|sqlscript|cypher|gremlin|mongo              -> sets console query language
+-- <comment>                                                   -> comment (no operation)
+quit|exit                                                      -> exits from the console
 ----
 
 NOTE: The `close` command can be used without path or url, then it closes the currently connected database.
 
-NOTE: The `comment` command is useful for scripts.
+NOTE: The comment command `--` is useful for scripts.
 
 [[Console-Tutorial]]
 ==== Tutorial
 
-Let's create our first database, located in our local filesystem. To identify the database you specify in a connection string. It could be either absolute, or relative to the database directory. The database directoty can be explicitely set, when you start the console, like 
+Let's create our first database, located in our local filesystem.
+To identify the database you specify in a connection string.
+It could be either absolute, or relative to the database directory.
+The database directory can be explicitely set, when you start the console, like 
 
 [source,shell]
 ----
-    ./bin/console.sh -Darcadedb.server.databaseDirectory=/Users/<USER-ID>/Arcadedb
+~/arcadedb $ ./bin/console.sh -Darcadedb.server.databaseDirectory=/databases
 ----
 
 If no database directory is given at startup, it is the `databases` directory under the root path of the arcadedb server by default.
@@ -59,18 +62,13 @@ To create a new database under the database directory, you would run the followi
 [source,shell]
 ----
 > create database mydb
-
-{mydb}>
 ----
 
-If you want to create your database somwhere else in the local filesystem, you would use an absolute path to the db, prefixed with "local:".
-Like:
+If you want to create your database somwhere else in the local filesystem, you would use an absolute path to the database, prefixed with `local:`, like:
 
 [source,shell]
 ----
-> create database local://Users/<USER-ID>/Arcadedb/mydb
-
-{mydb}
+> create database local://data/mydb
 ----
 
 If you already have a database, you can simply connect to it:
@@ -78,17 +76,13 @@ If you already have a database, you can simply connect to it:
 [source,shell]
 ----
 > connect mydb
-
-{mydb}>
 ----
 
 or:
 
 [source,shell]
 ----
-> connect local://Users/<USER-ID>/Arcadedb/mydb
-
-{mydb}>
+> connect local://data/mydb
 ----
 
 This is how you create a or connect to a database without an intermediate ArcadeDB server. 
@@ -154,7 +148,8 @@ DOCUMENT @type:Profile @rid:#1:0
 Command executed in 17ms
 ----
 
-You can see your brand new record with RID #1:0. Now let's query the database to see if our new document can be found:
+You can see your brand new record with RID `#1:0`.
+Now let's query the database to see if our new document can be found:
 
 [source,shell]
 ----
@@ -183,6 +178,13 @@ The console can also run local SQL scripts:
 [source,shell]
 ----
 ~/arcadedb $ bin/console.sh myscript.sql
+----
+
+or run commands passed as string argument:
+
+[source,shell]
+----
+~/arcadedb $ bin/console.sh "CREATE DATABASE test; CREATE DOCUMENT TYPE doc; BACKUP DATABASE; exit;"
 ----
 
 NOTE: Make sure to `create database` or `connect` to a database first in the script before using <<SQL,SQL commands>>.


### PR DESCRIPTION
* Fix position of remark on supported types in SQL `CREATE PROPERTY` (Section 8.4)
* Clean up, add example for arument passed scripting and make console section more consistent (Section 6.1)