### PR TITLE
fix typo in scoop installer instructions

### DIFF
--- a/src/main/asciidoc/introduction/run.adoc
+++ b/src/main/asciidoc/introduction/run.adoc
@@ -60,7 +60,7 @@ Instead of using manual install you can use Scoop installer, instructions are av
 [#scoop-installer,powershell]
 ----
 scoop bucket add extras
-scoop install arcadeb
+scoop install arcadedb
 ----
 
 This downloads and installs ArcadeDB on your box and makes following two commands available:


### PR DESCRIPTION
During last contribution we overlooked a typo in install instructions.
