### PR TITLE
Fix docs issues

### DIFF
--- a/src/main/asciidoc/api/http.adoc
+++ b/src/main/asciidoc/api/http.adoc
@@ -127,9 +127,9 @@ Let's first create an empty database "school" on the server:
 
 [source,shell]
 ----
-curl -X POST http://localhost:2480/api/v1/server
-     -d '{ "command": "create database school" }'
-     -H "Content-Type: application/json"
+curl -X POST http://localhost:2480/api/v1/server \
+     -d '{ "command": "create database school" }' \
+     -H "Content-Type: application/json" \
      --user root:arcadedb-password
 ----
 
@@ -137,9 +137,9 @@ Now let's create the type "Class":
 
 [source,shell]
 ----
-curl -X POST http://localhost:2480/api/v1/command/school
-     -d '{ "language": "sql", "command": "create document type Class"}'
-     -H "Content-Type: application/json"
+curl -X POST http://localhost:2480/api/v1/command/school \
+     -d '{ "language": "sql", "command": "create document type Class"}' \
+     -H "Content-Type: application/json" \
      --user root:arcadedb-password
 ----
 
@@ -147,9 +147,9 @@ We could insert our first Class by using SQL:
 
 [source,shell]
 ----
-curl -X POST http://localhost:2480/api/v1/command/school
-     -d '{ "language": "sql", "command": "insert into Class set name = '\''English'\'', location = '\''3rd floor'\''"}'
-     -H "Content-Type: application/json"
+curl -X POST http://localhost:2480/api/v1/command/school \
+     -d '{ "language": "sql", "command": "insert into Class set name = '\''English'\'', location = '\''3rd floor'\''"}' \
+     -H "Content-Type: application/json" \
      --user root:arcadedb-password
 ----
 
@@ -157,9 +157,9 @@ Or better, using parameters with SQL:
 
 [source,shell]
 ----
-curl -X POST http://localhost:2480/api/v1/command/school
-     -d '{ "language": "sql", "command": "insert into Class set name = :name, location = :location", "params": { "name": "English", "location": "3rd floor" }}'
-     -H "Content-Type: application/json"
+curl -X POST http://localhost:2480/api/v1/command/school \
+     -d '{ "language": "sql", "command": "insert into Class set name = :name, location = :location", "params": { "name": "English", "location": "3rd floor" }}' \
+     -H "Content-Type: application/json" \
      --user root:arcadedb-password
 ----
 
@@ -167,9 +167,9 @@ Or by using the `api/v1/document` API:
 
 [source,shell]
 ----
-curl -X POST http://localhost:2480/api/v1/document/school
-     -d '{"@type": "Class", "name": "English", "location": "3rd floor"}'
-     -H "Content-Type: application/json"
+curl -X POST http://localhost:2480/api/v1/document/school \
+     -d '{"@type": "Class", "name": "English", "location": "3rd floor"}' \
+     -H "Content-Type: application/json" \
      --user root:arcadedb-password
 ----
 
@@ -217,7 +217,7 @@ Example:
 
 [source,shell]
 ----
-curl -X GET http://localhost:2480/api/v1/server?mode=basic
+curl -X GET http://localhost:2480/api/v1/server?mode=basic \
      --user root:arcadedb-password
 ----
 
@@ -519,7 +519,7 @@ URL Syntax: `/api/v1/exists/{database}`
 
 [source,shell]
 ----
-curl -X GET http://localhost:2480/api/v1/exists/school
+curl -X GET http://localhost:2480/api/v1/exists/school \
      --user root:arcadedb-password
 ----
 
@@ -561,7 +561,7 @@ Example:
 
 [source,shell]
 ----
-curl -X GET http://localhost:2480/api/v1/query/school/sql/select%20from%20Class
+curl -X GET http://localhost:2480/api/v1/query/school/sql/select%20from%20Class \
      --user root:arcadedb-password
 ----
 
@@ -569,9 +569,9 @@ The `query` endpoint may also be used via the POST method, which has no characte
 
 [source,shell]
 ----
-curl -X POST http://localhost:2480/api/v1/query/school
-     -d '{ "language": "sql", "command": "select from Class" }'
-     -H "Content-Type: application/json"
+curl -X POST http://localhost:2480/api/v1/query/school \
+     -d '{ "language": "sql", "command": "select from Class" }' \
+     -H "Content-Type: application/json" \
      --user root:arcadedb-password
 ----
 
@@ -591,9 +591,9 @@ Example to create the new document type "Class":
 
 [source,shell]
 ----
-curl -X POST http://localhost:2480/api/v1/command/school
-     -d '{ "language": "sql", "command": "create document type Class"}'
-     -H "Content-Type: application/json"
+curl -X POST http://localhost:2480/api/v1/command/school \
+     -d '{ "language": "sql", "command": "create document type Class"}' \
+     -H "Content-Type: application/json" \
      --user root:arcadedb-password
 ----
 
@@ -613,9 +613,9 @@ Example of insertion of a new Client by using parameters:
 
 [source,shell]
 ----
-curl -X POST http://localhost:2480/api/v1/command/company
-     -d '{ "language": "sql", "command": "create vertex Client set firstName = :firstName, lastName = :lastName", params: { "firstName": "Jay", "lastName", "Miner" } }'
-     -H "Content-Type: application/json"
+curl -X POST http://localhost:2480/api/v1/command/company \
+     -d '{ "language": "sql", "command": "create vertex Client set firstName = :firstName, lastName = :lastName", params: { "firstName": "Jay", "lastName", "Miner" } }' \
+     -H "Content-Type: application/json" \
      --user root:arcadedb-password
 ----
 
@@ -640,10 +640,11 @@ The payload, optional as a JSON, accepts the following parameters:
 
 Example:
 
-```
-curl -X POST http://localhost:2480/api/v1/begin/school
+[source,shell]
+----
+curl -X POST http://localhost:2480/api/v1/begin/school \
      --user root:arcadedb-password -I
-```
+----
 
 Returns the Session Id in the response header, example:
 
@@ -673,8 +674,8 @@ Example:
 
 [source,shell]
 ----
-curl -X POST http://localhost:2480/api/v1/commit/school
-     -H "arcadedb-session-id: AS-ee056170-dc9b-4956-8d71-d7cfa01900d4"
+curl -X POST http://localhost:2480/api/v1/commit/school \
+     -H "arcadedb-session-id: AS-ee056170-dc9b-4956-8d71-d7cfa01900d4" \
      --user root:arcadedb-password
 ----
 
@@ -699,7 +700,7 @@ Example:
 
 [source,shell]
 ----
-curl -X POST http://localhost:2480/api/v1/rollback/school
-     -H "arcadedb-session-id: AS-ee056170-dc9b-4956-8d71-d7cfa01900d4"
+curl -X POST http://localhost:2480/api/v1/rollback/school \
+     -H "arcadedb-session-id: AS-ee056170-dc9b-4956-8d71-d7cfa01900d4" \
      --user root:arcadedb-password
 ----

--- a/src/main/asciidoc/api/http.adoc
+++ b/src/main/asciidoc/api/http.adoc
@@ -247,6 +247,11 @@ The following commands are available:
 * `drop user <username>` deletes user `username`
 * `get server events [<filename>]` returns a list of server events, optionally a filename of the form `server-event-log-yyyymmdd-HHMMSS.INDEX.jsonl` (where `INDEX` is a integer, i.e. `0`) can be given to retrieve older event logs
 * `shutdown` kills the server gracefully.
+* `set server setting <key> <value>` sets the server setting with `key` to `value`, see the <<Setting-Table,list of server-level settings>>
+* `set database setting <dbname> <key> <value>` sets the database's <dbname> with `key` to `value`, see the <<Setting-Table,list of database-level settings>>
+* `connect cluster <address>` connects this server to a cluster with `address`
+* `disconnect cluster` disconnects this server from a cluster
+* `align database <dbname>` aligns database `<dbname>`, see the associated <<_sql-align-database,SQL command>>
 
 NOTE: Only *root* users can run these command, except the `list databases` command, which every user can run, and this user's accessible databases are listed.
 
@@ -257,9 +262,9 @@ Examples:
 
 [source,shell]
 ----
-curl -X POST http://localhost:2480/api/v1/server
-     -d '{ "command": "list databases" }'
-     -H "Content-Type: application/json"
+curl -X POST http://localhost:2480/api/v1/server \
+     -d '{ "command": "list databases" }' \
+     -H "Content-Type: application/json" \
      --user root:arcadedb-password
 ----
 
@@ -275,9 +280,9 @@ Return:
 
 [source,shell]
 ----
-curl -X POST http://localhost:2480/api/v1/server
-     -d '{ "command": "create database mydatabase" }'
-     -H "Content-Type: application/json"
+curl -X POST http://localhost:2480/api/v1/server \
+     -d '{ "command": "create database mydatabase" }' \
+     -H "Content-Type: application/json" \
      --user root:arcadedb-password
 ----
 
@@ -293,9 +298,9 @@ Return:
 
 [source,shell]
 ----
-curl -X POST http://localhost:2480/api/v1/server
-     -d '{ "command": "drop database mydatabase" }'
-     -H "Content-Type: application/json"
+curl -X POST http://localhost:2480/api/v1/server \
+     -d '{ "command": "drop database mydatabase" }' \
+     -H "Content-Type: application/json" \
      --user root:arcadedb-password
 ----
 
@@ -311,9 +316,9 @@ Return:
 
 [source,shell]
 ----
-curl -X POST http://localhost:2480/api/v1/server
-     -d '{ "command": "open database mydatabase" }'
-     -H "Content-Type: application/json"
+curl -X POST http://localhost:2480/api/v1/server \
+     -d '{ "command": "open database mydatabase" }' \
+     -H "Content-Type: application/json" \
      --user root:arcadedb-password
 ----
 
@@ -329,9 +334,9 @@ Return:
 
 [source,shell]
 ----
-curl -X POST http://localhost:2480/api/v1/server
-     -d '{ "command": "close database mydatabase" }'
-     -H "Content-Type: application/json"
+curl -X POST http://localhost:2480/api/v1/server \
+     -d '{ "command": "close database mydatabase" }' \
+     -H "Content-Type: application/json" \
      --user root:arcadedb-password
 ----
 
@@ -347,9 +352,9 @@ Return:
 
 [source,shell]
 ----
-curl -X POST http://localhost:2480/api/v1/server
-     -d '{ "command": "create user { \"name\": \"myuser\", \"password\": \"mypassword\", \"databases\": { \"mydatabase\": \"admin\" } }" }'
-     -H "Content-Type: application/json"
+curl -X POST http://localhost:2480/api/v1/server \
+     -d '{ "command": "create user { \"name\": \"myuser\", \"password\": \"mypassword\", \"databases\": { \"mydatabase\": \"admin\" } }" }' \
+     -H "Content-Type: application/json" \
      --user root:arcadedb-password
 ----
 
@@ -365,9 +370,9 @@ Return:
 
 [source,shell]
 ----
-curl -X POST http://localhost:2480/api/v1/server
-     -d '{ "command": "drop user myuser" }'
-     -H "Content-Type: application/json"
+curl -X POST http://localhost:2480/api/v1/server \
+     -d '{ "command": "drop user myuser" }' \
+     -H "Content-Type: application/json" \
      --user root:arcadedb-password
 ----
 
@@ -383,9 +388,9 @@ Return:
 
 [source,shell]
 ----
-curl -X POST http://localhost:2480/api/v1/server
-     -d '{ "command": "shutdown" }'
-     -H "Content-Type: application/json"
+curl -X POST http://localhost:2480/api/v1/server \
+     -d '{ "command": "shutdown" }' \
+     -H "Content-Type: application/json" \
      --user root:arcadedb-password
 ----
 
@@ -397,13 +402,13 @@ Return:
 ----
 
 [discrete]
-====== Server events
+====== Get server events
 
 [source,shell]
 ----
-curl -X POST http://localhost:2480/api/v1/server
-     -d '{ "command": "get server events" }'
-     -H "Content-Type: application/json"
+curl -X POST http://localhost:2480/api/v1/server \
+     -d '{ "command": "get server events" }' \
+     -H "Content-Type: application/json" \
      --user root:arcadedb-password
 ----
 
@@ -412,6 +417,96 @@ Return:
 [source,json]
 ----
 { "result": [{"time":"2023-06-18 15:37:40.378","type":"INFO","component":"Server","message":"ArcadeDB Server started in \u0027development\u0027 mode (CPUs\u003d8 MAXRAM\u003d4,00GB)"}]}
+----
+
+[discrete]
+====== Set server setting
+
+[source,shell]
+----
+curl -X POST http://localhost:2480/api/v1/server \
+     -d '{ "command": "set server setting arcadedb.server.name player0" }' \
+     -H "Content-Type: application/json" \
+     --user root:arcadedb-password
+----
+
+Return:
+
+[source,json]
+----
+{ "result" : "ok"}
+----
+
+[discrete]
+====== Set database setting
+
+[source,shell]
+----
+curl -X POST http://localhost:2480/api/v1/server \
+     -d '{ "command": "set database setting mydb arcadedb.flushOnlyAtClose true" }' \
+     -H "Content-Type: application/json" \
+     --user root:arcadedb-password
+----
+
+Return:
+
+[source,json]
+----
+{ "result" : "ok"}
+----
+
+[discrete]
+====== Connect cluster
+
+[source,shell]
+----
+curl -X POST http://localhost:2480/api/v1/server \
+     -d '{ "command": "connect cluster 192.168.0.1" }' \
+     -H "Content-Type: application/json" \
+     --user root:arcadedb-password
+----
+
+Return:
+
+[source,json]
+----
+{ "result" : "ok"}
+----
+
+[discrete]
+====== Disconnect cluster
+
+[source,shell]
+----
+curl -X POST http://localhost:2480/api/v1/server \
+     -d '{ "command": "disconnect cluster" }' \
+     -H "Content-Type: application/json" \
+     --user root:arcadedb-password
+----
+
+Return:
+
+[source,json]
+----
+{ "result" : "ok"}
+----
+
+[discrete]
+====== Align database
+
+[source,shell]
+----
+curl -X POST http://localhost:2480/api/v1/server \
+     -d '{ "command": "align database mydb" }' \
+     -H "Content-Type: application/json" \
+     --user root:arcadedb-password
+----
+
+Return:
+
+[source,json]
+----
+{ "result" : "ok"}
 ----
 
 [discrete]

--- a/src/main/asciidoc/concepts/inheritance.adoc
+++ b/src/main/asciidoc/concepts/inheritance.adoc
@@ -17,7 +17,7 @@ For example,
 [source,java]
 ----
 DocumentType account = database.getSchema().createDocumentType("Account");
-DocumentType company = database.getSchema().createDocumentType("Company").addParent(account);
+DocumentType company = database.getSchema().createDocumentType("Company").addSuperType(account);
 ----
 
 [discrete]

--- a/src/main/asciidoc/tools/console.adoc
+++ b/src/main/asciidoc/tools/console.adoc
@@ -134,7 +134,6 @@ AVAILABLE TYPES
 +-------+--------+-----------+-------------------------------------+-----------+-------------+
 |Profile|Document|0[]        |8[Profile_0,...,Profile_7]|0[]       |round-robin|             |
 +-------+--------+-----------+-------------------------------------+-----------+-------------+
-
 ----
 
 You can also query the defined types by executing the following SQL query: `select from schema:types`.
@@ -195,3 +194,18 @@ or run commands passed as string argument:
 ----
 
 NOTE: Make sure to `create database` or `connect` to a database first in the script before using <<SQL,SQL commands>>.
+
+[[Server-Interaction]]
+==== Console-Server Interaction
+
+NOTE: The console cannot access a database via local connection when a server is running.
+
+When the server is running it locks all (opened) databases,
+hence the console cannot access these databases via local connection which utilizes the file system.
+Nonetheless, the console can still connect to these databases via a remote connection,
+particularly, using `localhost` if the console is running on the same machine as the server:
+
+[source,shell]
+----
+> connect remote:localhost/mydb root arcadedb-password
+----

--- a/src/main/asciidoc/version.adoc
+++ b/src/main/asciidoc/version.adoc
@@ -1,1 +1,1 @@
-:revnumber: 23.6.1
+:revnumber: 23.7.1


### PR DESCRIPTION
* Update method name from `addParent()` to `addSuperType()` (Section 3.7) 
* Add paragraph about console-server interaction (Section 6.1)
* Add missing HTTP API server commands (Section 7.5)
* Make `curl` HTTP API examples copy-pasteable (Section 7.5)
* Update version to `23.7.1`