### PR TITLE
HTTP and INSERT Update

### DIFF
--- a/src/main/asciidoc/api/http.adoc
+++ b/src/main/asciidoc/api/http.adoc
@@ -11,6 +11,7 @@ image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/
 | <<#HTTP-CheckReady,Get server status>>      | GET    | `/api/v1/ready`
 | <<#HTTP-ServerInfo,Get server information>> | GET    | `/api/v1/server`
 | <<#HTTP-ServerCommand,Send server command>> | POST   | `/api/v1/server`
+| <<#HTTP-ListDatabases,List databases>>      | GET    | `/api/v1/databases`
 | <<#HTTP-DatabaseExists,Does database exist>>| GET    | `/api/v1/exists/{database}`
 | <<#HTTP-ExecuteQuery,Execute a query>>      | GET    | `/api/v1/query/{database}/{language}/{query}`
 | <<#HTTP-ExecuteQuery,Execute a query>>      | POST   | `/api/v1/query/{database}`
@@ -523,6 +524,34 @@ Return:
 [source,json]
 ----
 { "result" : "ok"}
+----
+
+[discrete]
+[[HTTP-ListDatabases]]
+===== List Databases (GET)
+
+Returns a list of available databases for the requesting user.
+
+URL Syntax: `/api/v1/databases`
+
+Responses:
+
+* https://httpstatuses.io/200[`200`] OK
+* https://httpstatuses.io/403[`403`] invalid credentials
+
+Example:
+
+[source,shell]
+----
+curl -X GET http://localhost:2480/api/v1/databases \
+     --user root:arcadedb-password
+----
+
+Return:
+
+[source,json,subs="+attributes"]
+----
+{"user":"root","version":"{revnumber}","serverName":"ArcadeDB_0","result":["school","mydatabase"]}
 ----
 
 [discrete]

--- a/src/main/asciidoc/sql/SQL-Create-Vertex.adoc
+++ b/src/main/asciidoc/sql/SQL-Create-Vertex.adoc
@@ -13,8 +13,9 @@ The Vertex and Edge are the main components of a Graph database. ArcadeDB suppor
 
 [source,sql]
 ----
-CREATE VERTEX [<type>] [BUCKET <bucket>] [SET <field> = <expression>[,]*]
-
+CREATE VERTEX [<type>] [BUCKET <bucket>]
+  [SET <field> = <expression>[,]*]|
+  [CONTENT {<JSON>}|[{<JSON>}[,]*]]
 ----
 
 * *`&lt;type&gt;`* Defines the type to which the vertex belongs.
@@ -55,6 +56,13 @@ ArcadeDB> CREATE VERTEX V1 SET brand = 'fiat', name = 'wow'
 
 ----
 ArcadeDB> CREATE VERTEX Employee CONTENT { "name" : "Jay", "surname" : "Miner" }
+----
+
+* Create multiple vertices using JSON content:
+
+----
+ArcadeDB> CREATE VERTEX Employee CONTENT [{"name" : "Jay", "surname" : "Miner"},
+            {"name": "Frank", "surname": "Hermier"},{"name": "Emily", "surname": "Sout"}]
 ----
 
 For more information, see:

--- a/src/main/asciidoc/sql/SQL-Insert.adoc
+++ b/src/main/asciidoc/sql/SQL-Insert.adoc
@@ -14,13 +14,14 @@ The <<SQL-Insert,`INSERT`>> command creates a new record in the database. Record
 INSERT INTO [TYPE:]<type>|BUCKET:<bucket>|INDEX:<index>
   [(<field>[,]*) VALUES (<expression>[,]*)[,]*]|
   [SET <field> = <expression>|<sub-command>[,]*]|
-  [CONTENT {<JSON>}]
+  [CONTENT {<JSON>}|[{<JSON>}[,]*]]
   [RETURN <expression>] 
   [FROM <query>]
 
 ----
 
-* *`CONTENT`* Defines JSON data as an option to set field values.
+* *`SET`* Abbreviated syntax to set field values.
+* *`CONTENT`* Defines JSON data as an option to set field values of one or multiple records.
 * *`RETURN`* Defines an expression to return instead of the number of inserted records. You can use any valid SQL expression. The most common use-cases,
 ** `@rid` Returns the Record ID of the new record.
 ** `@this` Returns the entire new record.
@@ -73,10 +74,19 @@ ArcadeDB> INSERT INTO Profile BUCKET profile_recent SET name = 'Jay',
 ----
 
 * Insert several records at the same time:
+
 [source,sql]
 ----
 ArcadeDB> INSERT INTO Profile (name, surname) VALUES ('Jay', 'Miner'), 
             ('Frank', 'Hermier'), ('Emily', 'Sout')
+----
+
+again in JSON content syntax, a JSON array of the to-be-inserted objects is passed:
+
+[source,sql]
+----
+ArcadeDB> INSERT INTO Profile CONTENT [{"name": "Jay", "surname": "Miner"},
+            {"name": "Frank", "surname": "Hermier"},{"name": "Emily", "surname": "Sout"}]
 ----
 
 * Insert a new record, adding a relationship.
@@ -112,6 +122,7 @@ ArcadeDB> INSERT INTO Profiles SET name = 'Luca', friends = [#10:3, #10:4]
 ----
 
 * Inserts using <<SQL-Select,`SELECT`>> sub-queries
+
 [source,sql]
 ----
 ArcadeDB> INSERT INTO Diver SET name = 'Luca', buddy = (SELECT FROM Diver 
@@ -119,6 +130,7 @@ ArcadeDB> INSERT INTO Diver SET name = 'Luca', buddy = (SELECT FROM Diver
 ----
 
 * Inserts using <<SQL-Insert,`INSERT`>> sub-queries:
+
 [source,sql]
 ----
 ArcadeDB> INSERT INTO Diver SET name = 'Luca', buddy = (INSERT INTO Diver 
@@ -126,6 +138,7 @@ ArcadeDB> INSERT INTO Diver SET name = 'Luca', buddy = (INSERT INTO Diver
 ----
 
 * Inserting into a different bucket:
+
 [source,sql]
 ----
 ArcadeDB> INSERT INTO BUCKET:asiaemployee (name) VALUES ('Matthew')
@@ -142,6 +155,7 @@ ArcadeDB> INSERT INTO BUCKET:asiaemployee (@type, content) VALUES
 That inserts the document of the type `Employee` into the bucket `asiaemployee`.
 
 * Insert a new record, adding it as an embedded document:
+
 [source,sql]
 ----
 ArcadeDB> INSERT INTO Profile (name, address) VALUES ('Luca', { "@type": "d", 
@@ -149,17 +163,18 @@ ArcadeDB> INSERT INTO Profile (name, address) VALUES ('Luca', { "@type": "d",
 ----
 
 * Insert a record with a list property:
+
 [source,sql]
 ----
 ArcadeDB> INSERT INTO Profile SET friends = list("Joe","Jack","John")
 ----
 
 * Insert a record with a map property:
+
 [source,sql]
 ----
 ArcadeDB> INSERT INTO Profile SET address = map("home","Avenue Lane")
 ----
-
 
 * Insert from a query.
 


### PR DESCRIPTION
* (Re-)added `databases` endpoint reference entry (Section 7.5)
* Make `SQL INSERT` reference entry more consistent (Section 8.4)
* Add syntax and example for multiple `CONTENT` (JSON) `INSERT`s (Section 8.4)
* Add syntax and example for multiple `CONTENT` (JSON) `CREATE VERTEX`es (Section 8.4)