### PR TITLE
Update HTTP API and initial native-select docu

### DIFF
--- a/src/main/asciidoc/api/http.adoc
+++ b/src/main/asciidoc/api/http.adoc
@@ -23,14 +23,15 @@ image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/
 
 *Overview Query & Command Parameters*
 
-[cols="30,10,~",options="header"]
+[cols="2,1,~",options="header"]
 |===
-| *Parameters* | *Type*     | *Values*
-| language   | Required | "sql", "sqlscript", "graphql", "cypher", "gremlin", "mongo", and others
-| command    | Required | encoded command string
-| limit      | Optional | maximum number of results
-| params     | Optional | map of parameters
-| serializer | Optional | "graph", "record"
+| *Parameters*  | *Type*   | *Values*
+| language      | Required | "sql", "sqlscript", "graphql", "cypher", "gremlin", "mongo", and others
+| command       | Required | encoded command string
+| awaitResponse | Optional | set synchronous (true, default) or asynchronous (false) command
+| limit         | Optional | maximum number of results
+| params        | Optional | map of parameters
+| serializer    | Optional | "graph", "record"
 |===
 
 [discrete]
@@ -660,6 +661,7 @@ The payload, as a JSON, accepts the following parameters:
 
 - `language` is the query language used, between "sql", "sqlscript", "graphql", "cypher", "gremlin", "mongo" and any other language supported by ArcadeDB and available at runtime.
 - `command` the command to execute in encoded format
+- `awaitResponse` (optional) a boolean which is by default "true", if set to "false" the command will be executed asynchronously and only acknowledgement of receiving the command is responded. The completion of the command is noted in the log, yet no results of the command can be returned.
 - `limit` (optional) is the maximum number of results to return
 - `params` (optional), is the map of parameters to pass to the query engine
 - `serializer` (optional) specify the serializer used for the result:
@@ -671,6 +673,7 @@ This serializer is used by <<Studio,Studio>>.
 Responses:
 
 * https://httpstatuses.io/200[`200`] OK
+* https://httpstatuses.io/200[`202`] Accepted
 * https://httpstatuses.io/400[`400`] invalid language, invalid command
 * https://httpstatuses.io/403[`403`] invalid credentials
 

--- a/src/main/asciidoc/api/java-api-remote.adoc
+++ b/src/main/asciidoc/api/java-api-remote.adoc
@@ -4,17 +4,17 @@ ArcadeDB comes with a convenient Java library to work with a remote database.
 
 Add the following dependencies in your Maven pom.xml file under the tag `<dependencies>`:
 
-[source,xml]
+[source,xml, subs="+attributes"]
 ----
 <dependency>
     <groupId>com.arcadedb</groupId>
     <artifactId>arcadedb-engine</artifactId>
-    <version>23.1.2</version>
+    <version>{revnumber}</version>
 </dependency>
 <dependency>
     <groupId>com.arcadedb</groupId>
     <artifactId>arcadedb-network</artifactId>
-    <version>23.1.2</version>
+    <version>{revnumber}</version>
 </dependency>
 ----
 

--- a/src/main/asciidoc/api/java-tutorial.adoc
+++ b/src/main/asciidoc/api/java-tutorial.adoc
@@ -16,8 +16,8 @@ DatabaseFactory arcade = new DatabaseFactory("/databases/mydb");
 ----
 
 Pass the path in the file system where you want the database to be stored.
-In this case a new directory 'mydb' will be created under the path "/databases/" of your file system.
-You can also use a relative path like "databases/mydb".
+In this case a new directory 'mydb' will be created under the path `/databases/` of your file system.
+You can also use a relative path like `databases/mydb`.
 
 NOTE: A `<<DatabaseFactory,DatabaseFactory>>` object doesn't hold the `<<Database,Database>>` instances.
 It's up to you to close them once you have finished.

--- a/src/main/asciidoc/api/native-select.adoc
+++ b/src/main/asciidoc/api/native-select.adoc
@@ -1,0 +1,138 @@
+[[Native-Select]]
+=== Native-Select
+
+The native-select API is an alternative approach to query a database from Java.
+This API combines an object-oriented syntax with SQL semantics and enables faster query processing than SQL.
+
+Compare the following SQL and native-select queries:
+
+[source,sql]
+----
+SELECT test FROM mytype WHERE > 1 AND 
+----
+
+[source,java]
+----
+database.select().property("test").fromType("mytype").where().property().gt().value(1).and
+.parameter("value", i).vertices();
+----
+
+An important part of the query is the filtering.
+Filtering in native-select is done by chaining compatible objects.
+A filter is composed of a `SelectWhereLeftBlock`, `SelectWhereOperatorBlock`, and `SelectWhereRightBlock`.
+Filters are chained or filtering is completed by the `SelectWhereAfterBlock`.
+
+In the following tables are listed which group methods belonging to objects related to a native select query.
+The columns of these tables list the method signature, consisting of name, arguments and return type,
+a comment on its effect, and a corresponding SQL element.
+
+[discrete]
+==== `Select` Object
+
+[%header,cols="2,4,1"]
+|===
+| Signature | Comment | SQL
+| `select()` -> `Select` | Initializes a "native select" query. | `SELECT`
+|===
+
+[discrete]
+==== `Select` Methods
+
+[%header,cols="2,4,1"]
+|===
+| Signature | Comment | SQL
+| `property(String)` -> `Select` | Inserts a property by its name | 
+| `value(Object)` -> `Select` | Inserts a literal value |
+| `parameter(String)` -> `Select` | Inserts a named placeholder to be specified in the compiled query |
+|||
+| `fromType(String)` -> `Select` | Sets type to select from | `FROM`
+| `fromBuckets(String, ...)` -> `Select` | Sets bucket(s) to select from by name | `FROM`
+| `fromBuckets(Integer, ...)` -> `Select` | Sets bucket(s) to select from by number | `FROM`
+|||
+| `polymorphic(Boolean)` | Allow or disallow polymorphic queries |
+| `timeout(Long,TimeUnit,Boolean)` | Set a timeout for the query |
+| `json(JSONObject)` | paste native-select query as JSON object |
+|||
+| `where()` -> `SelectWhereLeftBlock` | Initializes a filtering | `WHERE`
+|===
+
+[discrete]
+==== `SelectWhereLeftBlock` Methods
+
+[%header,cols="2,4,1"]
+|===
+| Signature | Comment | SQL
+| `property(String)` -> `SelectWhereOperatorBlock` | Inserts a property by its name | 
+| `value(Object)` -> `SelectWhereOperatorBlock` | Inserts an explicit value |
+| `parameter(String)` -> `SelectWhereOperatorBlock` | Inserts a named placeholder to be specified in the compiled query |
+|===
+
+[discrete]
+==== `SelectWhereOperatorBlock` Methods
+
+[%header,cols="2,4,1"]
+|===
+| Signature | Comment | SQL
+| `eq()` -> `SelectWhereRightBlock` | | `=`
+| `neq()` -> `SelectWhereRightBlock` | | `!=`
+| `lt()` -> `SelectWhereRightBlock` | | `<`
+| `le()` -> `SelectWhereRightBlock` | | `<=`
+| `gt()` -> `SelectWhereRightBlock` | | `>`
+| `ge()` -> `SelectWhereRightBlock` | | `>=`
+| `like()` -> `SelectWhereRightBlock` | | `LIKE`
+| `ilike()` -> `SelectWhereRightBlock` | | `ILIKE`
+|===
+
+[discrete]
+==== `SelectWhereRightBlock` Methods
+
+[%header,cols="2,4,1"]
+|===
+| Signature | Comment | SQL
+| `property(String)` -> `SelectWhereAfterBlock` | Inserts a property by its name | 
+| `value(Object)` -> `SelectWhereAfterBlock` | Inserts an explicit value |
+| `parameter(String)` -> `SelectWhereAfterBlock` | Inserts a named placeholder to be specified in the compiled query |
+|===
+
+[discrete]
+==== `SelectWhereAfterBlock` Methods
+
+[%header,cols="2,4,1"]
+|===
+| `and()` -> `SelectWhereLeftBlock` | | `AND`
+| `or()` -> `SelectWhereLeftBlock` | | `OR`
+|===
+
+[discrete]
+==== `Select` and `SelectWhereAfterBlock` Methods
+
+[%header,cols="2,4,1"]
+|===
+| Signature | Comment | SQL
+| `orderBy(String,Boolean)` -> `Select` | Orders projections           | `ORDER BY ... DESC ASC`
+| `limit(Integer)` -> `Select` | Limits the number of results | `LIMIT`
+| `skip(Integer)` -> `Select` | Skips a number of results    | `SKIP`
+|||
+| `compile()` -> `SelectCompiled` | Compiles select query |
+|===
+
+
+[discrete]
+==== `SelectCompiled` Methods
+
+[%header,cols="2,4,1"]
+|===
+| Signature | Comment | SQL
+| `parameter(String,Object)` -> `SelectCompiled` | Inserts a value at a named placeholder |
+|||
+| `document()` -> `SelectIterator<Document>` | |
+| `vertices()` -> `SelectIterator<Vertex>`   | |
+| `edges()` -> `SelectIterator<Edge>`     | |
+|||
+| `json()` -> `JSONObject` | |
+|===
+
+==== Examples
+
+TODO
+

--- a/src/main/asciidoc/server/server.adoc
+++ b/src/main/asciidoc/server/server.adoc
@@ -4,7 +4,8 @@ image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/
 
 To start ArcadeDB as a server run the script `server.sh` under the `bin` directory of ArcadeDB distribution. If you're using MS Windows OS, replace `server.sh` with `server.bat`.
 
-```shell
+[source,shell]
+----
 ~/arcadedb $ bin/server.sh
 
  █████╗ ██████╗  ██████╗ █████╗ ██████╗ ███████╗██████╗ ██████╗
@@ -31,7 +32,7 @@ INFO  [ArcadeDBServer]  - JMX Metrics Started...
 +--------------------------------------------------------------------+
 
 Root password [BLANK=auto generate it]: *
-```
+----
 
 The first time the server is running, the root password must be inserted and confirmed.
 The hash (+salt) of the inserted password will be stored in the file `config/security.json`. To know more about this topic, look at <<Security,Security>>.
@@ -45,22 +46,26 @@ Check <<Security-Policy,Security Policy>>.
 You can skip the request for the password by passing it as a setting.
 Example:
 
-`-Darcadedb.server.rootPassword=this_is_a_password`
+[source,shell]
+----
+-Darcadedb.server.rootPassword=this_is_a_password
+----
 
 Once inserted the password for the root user, you should see this output.
 
-```shell
+[source,shell]
+----
 Root password [BLANK=auto generate it]: ***********
 *Please type the root password for confirmation (copy and paste will not work): ***********
 
-INFO  [HttpServer] <ArcadeDB_0> - Starting HTTP Server (host=0.0.0.0 port=2480)...
+INFO  [HttpServer] &lt;ArcadeDB_0&gt; - Starting HTTP Server (host=0.0.0.0 port=2480)...
 INFO  [undertow] starting server: Undertow - 2.2.10.Final
 INFO  [xnio] XNIO version 3.8.4.Final
 INFO  [nio] XNIO NIO Implementation Version 3.8.4.Final
 INFO  [threads] JBoss Threads version 3.1.0.Final
-INFO  [HttpServer] <ArcadeDB_0> - HTTP Server started (host=0.0.0.0 port=2480)
-INFO  [ArcadeDBServer] <ArcadeDB_0> ArcadeDB Server started (CPUs=16 MAXRAM=2.00GB)
-```
+INFO  [HttpServer] &lt;ArcadeDB_0&gt; - HTTP Server started (host=0.0.0.0 port=2480)
+INFO  [ArcadeDBServer] &lt;ArcadeDB_0&gt; ArcadeDB Server started (CPUs=16 MAXRAM=2.00GB)
+----
 
 By default, the following components start with the server:
 
@@ -71,9 +76,10 @@ In the output above, the name `ArcadeDB_0` is the server name.
 By default, `ArcadeDB_0` is used.
 To specify a different name define it with the setting <<Settings,`server.name`>>, example:
 
-```shell
+[source,shell]
+----
 ~/arcadedb $ bin/server.sh -Darcadedb.server.name=ArcadeDB_Europe_0
-```
+----
 
 In HA configuration, it's mandatory all the servers in cluster have different names.
 
@@ -82,9 +88,11 @@ In HA configuration, it's mandatory all the servers in cluster have different na
 To start the server from a location different than the ArcadeDB folder,
 for example, if starting the server as a service,
 set the environment variable `ARCADEDB_HOME` to the ArcadeDB folder:
-```shell
+
+[source,shell]
+----
 export ARCADEDB_HOME=/path/to/arcadedb
-```
+----
 
 ==== Server modes
 
@@ -104,9 +112,12 @@ The mode is controlled by the <<Setting-Table,`server.mode`>> setting with a def
 
 Instead of starting a server and then connect to it to create the default databases, ArcadeDB Server takes an initial default databases list by using the setting <<Settings,`server.defaultDatabases`>>.
 
-```shell
+[source,shell]
+----
 ~/arcadedb $ bin/server.sh "-Darcadedb.server.defaultDatabases=Universe[elon:musk]"
-```
+----
+
+NOTE: A default database without users still needs to include empty brackets, ie: `-Darcadedb.server.defaultDatabases=Multiverse[]`
 
 With the example above the database "Universe" will be created if doesn't exist, with user "elon", password "musk".
 
@@ -127,7 +138,8 @@ By default ArcadeDB does not log debug messages into the console and file. You c
 
 The default configuration is the following.
 
-```
+[source,linenums]
+----
 1  handlers = java.util.logging.ConsoleHandler, java.util.logging.FileHandler
 2  .level = INFO
 3  com.arcadedb.level = INFO
@@ -138,7 +150,7 @@ The default configuration is the following.
 8  java.util.logging.FileHandler.formatter = com.arcadedb.log.LogFormatter
 9  java.util.logging.FileHandler.limit=100000000
 10 java.util.logging.FileHandler.count=10
-```
+----
 
 Where:
 
@@ -155,9 +167,10 @@ Where:
 
 If you're running ArcadeDB in embedded mode, make sure you're using the logging setting by specifying the `arcadedb-log.properties` file at JVM startup:
 
-```
+[source,shell]
+----
 java ... -Djava.util.logging.config.file=$ARCADEDB_HOME/config/arcadedb-log.properties ...
-```
+----
 
 You can also use your own configuration for logging. In this case replace the path above with your own file.
 
@@ -166,7 +179,8 @@ You can also use your own configuration for logging. In this case replace the pa
 
 You can extend ArcadeDB server by creating custom plugins. A Plugin is a Java class that implements the interface `com.arcadedb.server.ServerPlugin`:
 
-```java
+[source,java]
+----
 public interface ServerPlugin {
   void startService();
 
@@ -179,13 +193,14 @@ public interface ServerPlugin {
   default void registerAPI(final HttpServer httpServer, final PathHandler routes) {
   }
 }
-```
+----
 
 Once registered the plugin (see below), ArcadeDB Server will instantiate your plugin class and will call the method `configure()` passing the server configuration. At startup of the server, the `startService()` method will be invoked. Instead, when the server is shut down, the `stopService()` will be invoked where you can free any resources used by the plugin. The method `registerAPI()`, if implemented, wil be invoked when the HTTP server is initializing where you can register your own HTTP commands. For more information about how to create custom HTTP commands, look at <<Custom-HTTP,Custom HTTP commands>>.
 
 Example:
 
-```java
+[source,java]
+----
 package com.yourpackage;
 
 public class MyPlugin implements ServerPlugin {
@@ -209,7 +224,7 @@ public class MyPlugin implements ServerPlugin {
     System.out.println( "Registering HTTP commands" );
   }
 }
-```
+----
 
 
 To register your plugin, register the name and add your class (with full package name) in
@@ -217,8 +232,9 @@ To register your plugin, register the name and add your class (with full package
 
 Example:
 
-```
+[source,shell]
+----
 java ... -Darcadedb.server.plugins=MyPlugin:com.yourpackage.MyPlugin ...
-```
+----
 
 In case of multiple plugins, use the comma to separate them.

--- a/src/main/asciidoc/server/server.adoc
+++ b/src/main/asciidoc/server/server.adoc
@@ -117,9 +117,9 @@ Instead of starting a server and then connect to it to create the default databa
 ~/arcadedb $ bin/server.sh "-Darcadedb.server.defaultDatabases=Universe[elon:musk]"
 ----
 
-NOTE: A default database without users still needs to include empty brackets, ie: `-Darcadedb.server.defaultDatabases=Multiverse[]`
-
 With the example above the database "Universe" will be created if doesn't exist, with user "elon", password "musk".
+
+NOTE: A default database without users still needs to include empty brackets, ie: `-Darcadedb.server.defaultDatabases=Multiverse[]`
 
 Once the server is started, multiple clients can be connected to the server by using one of the supported protocols:
 


### PR DESCRIPTION
* Use consistent source code blocks (Section 4)
* Add note on `defaultDatabases` without user creation (Section 4.1.3)
* Fix paths to monospace (Section 7.2.1)
* Use `{revnumber}` in `pom` excerpt (Section 7.4)
* Add `awaitResponse` parameter to HTTP API `command` (Section 7.6)
* Add initial "native-select" docu (not publicly visible)