### PR TITLE
Remove any() and all()

### DIFF
--- a/src/main/asciidoc/sql/SQL-Select.adoc
+++ b/src/main/asciidoc/sql/SQL-Select.adoc
@@ -90,15 +90,15 @@ ArcadeDB> SELECT * FROM animaltype WHERE races CONTAINS(name in ['European',
 * Return all records in the type `Profile` where any field contains the word `danger`:
 [source,sql]
 ----
-ArcadeDB> SELECT FROM Profile WHERE ANY() LIKE '%danger%'
+ArcadeDB> SELECT FROM Profile WHERE @this.values().asString() LIKE '%danger%'
 ----
 
-* Return any record where up to the third level of connections has some field that contains the word `danger`, ignoring case:
-[source,sql]
-----
-ArcadeDB> SELECT FROM Profile WHERE ANY() TRAVERSE(0, 3) ( 
-            ANY().toUpperCase().indexOf('danger') > -1 )
-----
+//* Return any record where up to the third level of connections has some field that contains the word `danger`, ignoring case:
+//[source,sql]
+//----
+//ArcadeDB> SELECT FROM Profile WHERE ANY() TRAVERSE(0, 3) (
+//            ANY().toUpperCase().indexOf('danger') > -1 )
+//----
 
 * Return all results on type `Profile`, ordered by the field `name` in descending order:
 [source,sql]
@@ -112,11 +112,11 @@ ArcadeDB> SELECT FROM Profile ORDER BY name DESC
 ArcadeDB> SELECT SUM(*) FROM Account GROUP BY city
 ----
 
-* Traverse records from a root node:
-[source,sql]
-----
-ArcadeDB> SELECT FROM #11:4 WHERE ANY() TRAVERSE(0,10) (address.city = 'Rome')
-----
+//* Traverse records from a root node:
+//[source,sql]
+//----
+//ArcadeDB> SELECT FROM #11:4 WHERE ANY() TRAVERSE(0,10) (address.city = 'Rome')
+//----
 
 * Return only a limited set of records:
 [source,sql]

--- a/src/main/asciidoc/sql/SQL-Traverse.adoc
+++ b/src/main/asciidoc/sql/SQL-Traverse.adoc
@@ -13,7 +13,7 @@ NOTE: In many cases, you may find it more efficient to use <<SQL-Select,`SELECT`
 
 [source,sql]
 ----
-TRAVERSE [<type.]field>|*|any()|all()
+TRAVERSE [<type.]field>|*
          [FROM <target>]
          [
            MAXDEPTH <number>
@@ -87,7 +87,7 @@ ArcadeDB> SELECT $path FROM ( TRAVERSE out() FROM V MAXDEPTH 10 )
 
 *Fields*
 
-Defines the fields that you want to traverse. If set to `*`, `any()` or `all()` then it traverses all fields. This can prove costly to performance and resource usage, so it is recommended that you optimize the command to only traverse the pertinent fields.
+Defines the fields that you want to traverse. If set to `*`, then it traverses all fields. This can prove costly to performance and resource usage, so it is recommended that you optimize the command to only traverse the pertinent fields.
 
 In addition to his, you can specify the fields at a type-level. <<Inheritance,Inheritance>> is supported. By specifying `Person.city` and the type `Customer` extends person, you also traverse fields in `Customer`.
 

--- a/src/main/asciidoc/sql/SQL-Where.adoc
+++ b/src/main/asciidoc/sql/SQL-Where.adoc
@@ -23,8 +23,8 @@ And `item` can be:
 |field|Document field|where _price_ &gt; 1000000
 |field&lt;indexes&gt;|Document field part. To know more about field part look at the full syntax: <<SQL-Bracket,Document-API-Property>>|where tags[name='Hi'] or tags[0...3] IN ('Hello') and employees IS NOT NULL
 |record attribute|Record attribute name with @ as prefix|where _@type_ = 'Profile'
-|any()|Represents any field of the Document. The condition is true if ANY of the fields matches the condition|where _any()_ like 'L%'
-|all()|Represents all the fields of the Document. The condition is true if ALL the fields match the condition|where _all()_ is null
+// |any()|Represents any field of the Document. The condition is true if ANY of the fields matches the condition|where _any()_ like 'L%'
+// |all()|Represents all the fields of the Document. The condition is true if ALL the fields match the condition|where _all()_ is null
 | <<SQL-Functions,Functions>> |Any <<SQL-Functions,Function>> between the defined ones|where distance(x, y, 52.20472, 0.14056 ) &lt;= 30
 |<<Filtering,$variable>>|Context variable prefixed with $|where $depth &lt;= 3
 |===


### PR DESCRIPTION
* Remove or comment out examples and references to unsupported `any()` and `all()` (Section 8)