### PR TITLE
Minor Fixes and Updates

### DIFF
--- a/src/main/asciidoc/api/http.adoc
+++ b/src/main/asciidoc/api/http.adoc
@@ -589,7 +589,9 @@ Return:
 
 This command allows executing idempotent commands, like `SELECT` and `MATCH`:
 
-URL Syntax: `/api/v1/query/{database}/{language}/{command}`
+URL Syntax GET: `/api/v1/query/{database}/{language}/{command}`
+
+URL Syntax POST: `/api/v1/query/{database}`
 
 Where:
 
@@ -606,7 +608,7 @@ NOTE: Question marks (`?`) cause the server to stop reading the query string whe
 To use question marks (inside strings) one can use `format('%c',63)`; in this case make sure to replace all percent symbols (`%`) in the format string with `%%`.
 
 These restrictions do not apply to the `POST` variant, where the `language` and `command`
-are send in the body.
+are send in the body. Optionally, the <<#HTTP-ExecuteCommand,`params` property>> maybe used in the body.
 
 NOTE: Even though a `POST` method is used, the query in `command` has to be idempotent.
 
@@ -682,7 +684,7 @@ Example of insertion of a new Client by using parameters:
 [source,shell]
 ----
 curl -X POST http://localhost:2480/api/v1/command/company \
-     -d '{ "language": "sql", "command": "create vertex Client set firstName = :firstName, lastName = :lastName", params: { "firstName": "Jay", "lastName", "Miner" } }' \
+     -d '{ "language": "sql", "command": "create vertex Client set firstName = :firstName, lastName = :lastName", params: { "firstName": "Jay", "lastName": "Miner" } }' \
      -H "Content-Type: application/json" \
      --user root:arcadedb-password
 ----

--- a/src/main/asciidoc/sql/SQL-Functions.adoc
+++ b/src/main/asciidoc/sql/SQL-Functions.adoc
@@ -826,7 +826,7 @@ Get all the outgoing vertices from all the "Vehicle" vertices:
 SELECT out() FROM Vehicle
 ----
 
-Get all the incoming vertices connected with edges with label (class) "Eats" and "Favorited" from all the "Restaurant" vertices in "Rome":
+Get all the outgoing vertices connected with edges with label (class) "Eats" and "Favorited" from all the "Restaurant" vertices in "Rome":
 
 [source,sql]
 ----

--- a/src/main/asciidoc/sql/SQL-Script.adoc
+++ b/src/main/asciidoc/sql/SQL-Script.adoc
@@ -66,11 +66,13 @@ The syntax is
 [source,sql]
 ----
 IF( <sql-predicate> ){
-   <statement>;
-   <statement>;
-   ...
+  <statement>;
+  <statement>;
+  ...
 }
 ----
+
+WARNING: There has to be a linebreak after `IF( <sql-predicate> ){` and `}` has to follow a linebreak.
 
 `&lt;sql-predicate&gt;` is any valid SQL predicate (any condition that can be used in a `WHERE` clause):
 

--- a/src/main/asciidoc/sql/SQL-Traverse.adoc
+++ b/src/main/asciidoc/sql/SQL-Traverse.adoc
@@ -150,7 +150,7 @@ This model is based on the concepts of the Vertex (or Node) and the Edge (or Arc
 * *Edge to Vertex (starting point)* Using `outV()` . That is, going back from an edge and into a vertex.
 * *Edge to Vertex (both sizes)* Using `bothV()` . That is, going from an edge and into connected vertices.
 * *Vertex to Vertex (outgoing edges)* Using `out()` or `out(&#39;EdgeTypeName&#39;)`. This is the same as `outE().inV()`
-* *Vertex to Vertex (incoming edges)* Using `in()` or `in(&#39;EdgeTypeName&#39;)`. This is the same as `outE().inV()`
+* *Vertex to Vertex (incoming edges)* Using `in()` or `in(&#39;EdgeTypeName&#39;)`. This is the same as `inE().outV()`
 * *Vertex to Vertex (all directions)* Using `both()` or `both(&#39;EdgeTypeName&#39;)`.
 
 For instance, traversing outgoing edges on the record `#10:3434`:

--- a/src/main/asciidoc/version.adoc
+++ b/src/main/asciidoc/version.adoc
@@ -1,1 +1,1 @@
-:revnumber: 23.10.1
+:revnumber: 23.11.1


### PR DESCRIPTION
* Update version to 23.11.1
* Add comment about `params` to POST variant of query endoint (Section 7.6)
* Fix typo in example of command endpoint (Section 7.6)
* Fix typo in SQL function `out()` (Section 8.3)
* Fix typo in SQL command `TRAVERSE` (Section 8.2)
* Add warning about linebreaks in SQL Script `IF` again (Section 8.5)
    In my earlier test this did not seem to play a role, but in nested situations (and maybe others) this seems required.