### PR TITLE
Document `rootPasswordPath` Setting

### DIFF
--- a/src/main/asciidoc/appendix/settings.adoc
+++ b/src/main/asciidoc/appendix/settings.adoc
@@ -140,6 +140,7 @@ If you're embedding a server in your Java application you can use these settings
 |`server.name`|Server name|String|ArcadeDB_0
 |`server.plugins`|Server plugins to load, see <<#_available-plugins,available plugins>>. Format as comma separated list of: `<pluginName>:<pluginFullClass>`.|String|
 |`server.rootPassword`|Password for root user to use at first startup of the server. Set this to avoid asking the password to the user|String|null
+|`server.rootPasswordPath`|Path to file with password for root user to use at first startup of the server. Set this to avoid asking the password to the user|String|null
 |`server.rootPath`|Root path in the file system where the server is looking for files. By default is the current directory|String|null
 |`server.securityAlgorithm`|Default encryption algorithm used for passwords hashing|String|PBKDF2WithHmacSHA256
 |`server.securitySaltCacheSize`|Cache size of hashed salt passwords. The cache works as LRU. Use 0 to disable the cache|Integer|64

--- a/src/main/asciidoc/security/secrets.adoc
+++ b/src/main/asciidoc/security/secrets.adoc
@@ -21,13 +21,22 @@ directly into the JVM (alternatively https://docs.oracle.com/en/java/javase/11/t
 However, just using this particular environment variable would mean that the
 JVM writes the contents of this variable to the standard error stream,
 which means the secrets would appear in logs.
-To suppress this logging, a https://superuser.com/a/585696/1824014[workaround] can be used
-by wrapping the `server.sh` script:
+
+For the root password this can be avoided using the setting:
+```
+-Darcadedb.server.rootPasswordPath=/path/to/root_secret
+```
+which passes the secret via a plain text file which is mounted to a known path inside the container.
+This is a common practice to pass secrets to containers, for example with Docker compose.
+
+To suppress this logging for non-root secrets,
+a https://superuser.com/a/585696/1824014[workaround] can be used
+by providing the secret also file-based and wrapping the `server.sh` script:
 
 ```shell
 #!/bin/sh
 
-export JAVA_TOOL_OPTIONS="-Darcadedb.server.rootPassword=`cat /path/to/root_secret` -Darcadedb.server.defaultDatabases=database1[user1:`cat /path/to/user_secret`]"
+export JAVA_TOOL_OPTIONS="-Darcadedb.server.defaultDatabases=database1[user1:`cat /path/to/user_secret`]"
 ./bin/server.sh 2> >(grep -v "^Picked up JAVA_TOOL_OPTIONS:") &
 
 PID="$!"

--- a/src/main/asciidoc/server/server.adoc
+++ b/src/main/asciidoc/server/server.adoc
@@ -51,6 +51,16 @@ Example:
 -Darcadedb.server.rootPassword=this_is_a_password
 ----
 
+Alternatively the password can be passed file-based.
+Example:
+
+[source,shell]
+----
+-Darcadedb.server.rootPasswordPath=/run/secrets/root
+----
+
+NOTE: The password file is a plain-text file and should not contain any line breaks / new lines.
+
 Once inserted the password for the root user, you should see this output.
 
 [source,shell]


### PR DESCRIPTION
* Add example for using `rootPasswordPath` setting (Section 4.1)
* Update secrets handling advise by mentioning `rootPasswordPath` setting (Section 9.4)
* Add `rootPasswordPath` to settings table (Section 11.2)