### PR TITLE
Fixes and Extensions

### DIFF
--- a/src/main/asciidoc/api/gremlin.adoc
+++ b/src/main/asciidoc/api/gremlin.adoc
@@ -103,7 +103,7 @@ In order to use the Gremlin Server with ArcadeDB, you have to enable it from Arc
 ~/arcadedb $ bin/server.sh -Darcadedb.server.plugins="GremlinServer:com.arcadedb.server.gremlin.GremlinServerPlugin"
 ----
 
-If you're using MS Windows OS, replace `server.sh` with `server.bat`.
+If you're using MS Windows OS, replace `bin/server.sh` with `bin\server.bat`.
 
 At startup, the Gremlin Server plugin looks for the file `config/gremlin-server.yaml` under ArcadeDB path.
 If the file is present, the Gremlin Server will be configured with the settings contained in the YAML file, otherwise the default configuration will be used.

--- a/src/main/asciidoc/api/http.adoc
+++ b/src/main/asciidoc/api/http.adoc
@@ -599,6 +599,7 @@ Where:
 - `language` is the query language used.
 is the query language used, between "sql", "sqlscript", "graphql", "cypher", "gremlin", "mongo" and any other language supported by ArcadeDB and available at runtime.
 - `command` the command to execute in encoded format
+- `params` (optional), is the map of parameters to pass to the query engine via the POST body, where parameters are introduced with a colon `:`.
 
 When using the `GET` variant the query needs to be URL encoded.
 
@@ -665,7 +666,7 @@ The payload, as a JSON, accepts the following parameters:
 - `command` the command to execute in encoded format
 - `awaitResponse` (optional) a boolean which is by default "true", if set to "false" the command will be executed asynchronously and only acknowledgement of receiving the command is responded. The completion of the command is noted in the log, yet no results of the command can be returned.
 - `limit` (optional) is the maximum number of results to return
-- `params` (optional), is the map of parameters to pass to the query engine
+- `params` (optional), is the map of parameters to pass to the query engine, where parameters are introduced with a colon `:`.
 - `serializer` (optional) specify the serializer used for the result:
 ** `graph`: returns as a graph separating vertices from edges
 ** `record`: returns everything as records

--- a/src/main/asciidoc/api/postgres.adoc
+++ b/src/main/asciidoc/api/postgres.adoc
@@ -56,7 +56,7 @@ Check out the following list with the official drivers for the most popular prog
 - https://github.com/lib/pq[Go]
 - https://github.com/brianc/node-postgres[Javascript - Node.js]
 - https://www.php.net/manual/en/book.pgsql.php[PHP]
-- https://github.com/MagicStack/asyncpg[Python]
+- https://www.psycopg.org/docs/[Python]
 - https://cran.r-project.org/web/packages/RPostgreSQL/index.html[R]
 - https://github.com/ged/ruby-pg[Ruby]
 - https://github.com/sfackler/rust-postgres[Rust]

--- a/src/main/asciidoc/concepts/basics.adoc
+++ b/src/main/asciidoc/concepts/basics.adoc
@@ -231,8 +231,24 @@ arcadeDB> SELECT FROM BUCKET:[Customer_Europe_Italy,Customer_Europe_Spain]
 [[Relationships]]
 === Relationships
 
-ArcadeDB supports two kinds of relationships: **referenced** and **embedded**.
+ArcadeDB supports three kinds of relationships: **connections**, **referenced** and **embedded**.
 It can manage relationships in a schema-full or schema-less scenario.
+
+[discrete]
+==== Graph Connections
+
+As a graph database, spanning edges between vertices is one way to express a connections between records.
+This is graph model's natural way of relationsships and traversable by the SQL, Gremlin, and Cypher query languages. Internally, ArcadeDB deposes a direct (referenced) relationship for edge-wise connected vertices to ensure fast graph traversals.
+
+Example
+
+```
+    Vertex A -------------> Edge X -------------> Vertex B
+ TYPE=Customer           TYPE=isBilled          TYPE=Invoice
+    RID #5:23              RID #16:9              RID #10:2
+```
+
+In ArcadeDB's SQL, edges are created via the <<SQL-Create-Edge,`CREATE EDGE`>> command.
 
 [discrete]
 ==== Referenced Relationships

--- a/src/main/asciidoc/server/docker.adoc
+++ b/src/main/asciidoc/server/docker.adoc
@@ -57,6 +57,31 @@ You should see the first 100 beers in the database and all their connections.
 image::../images/openbeer-demo-graph.png[alt="Demo Database Graph",align="center"]
 
 [discrete]
+==== Persistence
+
+There are multiple options to make databases in an ArcadeDB container persistent,
+yet the practical choice is highly dependent on the application and environment.
+
+On the Docker side there are two typical options to persist data in a container:
+
+1. A https://docs.docker.com/storage/volumes/[Docker volume] which is a Docker managed section of the host's filesystem. This would be the preferred option if the host machine is to store the persistent data.
+
+2. A https://docs.docker.com/storage/bind-mounts/[Bind mount] which is a user-managed folder of the host's filesystem. This can be used if the target volume is itself mounted on the host like a network share.
+
+See the https://docs.docker.com/storage/[Docker storage] documentation on how to set up volumes or mounts.
+
+On the ArcadeDB side there are basically two options to consider:
+
+1. Store the database itself on an external volume. In this case all read and write operations from and to a database take place on the specified volume or mount, which can entail performance limitations.
+  Use the setting `-Darcadedb.server.databaseDirectory=/mydatabases` to specify the mount-point of the volume or mount as absolute path to ArcadeDB.
+
+2. Store only backups on an external volume. In this approach all read and write operation from and to a database happen in the storage provided by Docker to the container. This is faster if the host can provide local storage.
+  However, the user needs to take care of regular backups, see <<SQL-Backup-Database,`BACKUP DATABASE`>>, for which the default backup folder can be set by `-Darcadedb.server.backupDirectory=/mybackup` to specify the mount-point of the volume or mount as absolute path to ArcadeDB.
+
+NOTE: Which combination is most suitable depends on the computational environment. For example,
+"local storage" can have different meanings on a bare metal machine, a virtual machine or container cluster.
+
+[discrete]
 [[DockerTuning]]
 ==== Tuning
 


### PR DESCRIPTION
* Add paragraph about edge relationships (Section 3.4)
* Add subsection about persistence to Docker section (Section 4.5)
* Add `params` optional property bullet to POST-method `query` endpoint (Section 7.7)
* Replace Python Postgres with`psycopg2` (Section 7.11) 
* More precise server call (Section 7.14)