### PR TITLE
Make source blocks more consistent, add small SQL translation table, render ASCII diagrams

### DIFF
--- a/src/main/asciidoc/api/http.adoc
+++ b/src/main/asciidoc/api/http.adoc
@@ -138,40 +138,40 @@ Let's first create an empty database "school" on the server:
 
 [source,shell]
 ----
-curl -X POST http://localhost:2480/api/v1/server \
-     -d '{ "command": "create database school" }' \
-     -H "Content-Type: application/json" \
-     --user root:arcadedb-password
+$ curl -X POST http://localhost:2480/api/v1/server \
+       -d '{ "command": "create database school" }' \
+       -H "Content-Type: application/json" \
+       --user root:arcadedb-password
 ----
 
 Now let's create the type "Class":
 
 [source,shell]
 ----
-curl -X POST http://localhost:2480/api/v1/command/school \
-     -d '{ "language": "sql", "command": "create document type Class"}' \
-     -H "Content-Type: application/json" \
-     --user root:arcadedb-password
+$ curl -X POST http://localhost:2480/api/v1/command/school \
+       -d '{ "language": "sql", "command": "create document type Class"}' \
+       -H "Content-Type: application/json" \
+       --user root:arcadedb-password
 ----
 
 We could insert our first Class by using SQL:
 
 [source,shell]
 ----
-curl -X POST http://localhost:2480/api/v1/command/school \
-     -d '{ "language": "sql", "command": "insert into Class set name = '\''English'\'', location = '\''3rd floor'\''"}' \
-     -H "Content-Type: application/json" \
-     --user root:arcadedb-password
+$ curl -X POST http://localhost:2480/api/v1/command/school \
+       -d '{ "language": "sql", "command": "insert into Class set name = '\''English'\'', location =  '\''3rd floor'\''"}' \
+       -H "Content-Type: application/json" \
+       --user root:arcadedb-password
 ----
 
 Or better, using parameters with SQL:
 
 [source,shell]
 ----
-curl -X POST http://localhost:2480/api/v1/command/school \
-     -d '{ "language": "sql", "command": "insert into Class set name = :name, location = :location", "params": { "name": "English", "location": "3rd floor" }}' \
-     -H "Content-Type: application/json" \
-     --user root:arcadedb-password
+$ curl -X POST http://localhost:2480/api/v1/command/school \
+       -d '{ "language": "sql", "command": "insert into Class set name = :name, location = :location", "params": { "name": "English", "location": "3rd floor" }}' \
+       -H "Content-Type: application/json" \
+       --user root:arcadedb-password
 ----
 
 [discrete]
@@ -195,7 +195,7 @@ Example:
 
 [source,shell]
 ----
-curl -I -X GET "http://localhost:2480/api/v1/ready"
+$ curl -I -X GET "http://localhost:2480/api/v1/ready"
 ----
 
 Return:
@@ -228,8 +228,8 @@ Example:
 
 [source,shell]
 ----
-curl -X GET "http://localhost:2480/api/v1/server?mode=basic" \
-     --user root:arcadedb-password
+$ curl -X GET "http://localhost:2480/api/v1/server?mode=basic" \
+       --user root:arcadedb-password
 ----
 
 Return:
@@ -280,10 +280,10 @@ Examples:
 
 [source,shell]
 ----
-curl -X POST http://localhost:2480/api/v1/server \
-     -d '{ "command": "list databases" }' \
-     -H "Content-Type: application/json" \
-     --user root:arcadedb-password
+$ curl -X POST http://localhost:2480/api/v1/server \
+       -d '{ "command": "list databases" }' \
+       -H "Content-Type: application/json" \
+       --user root:arcadedb-password
 ----
 
 Return:
@@ -298,10 +298,10 @@ Return:
 
 [source,shell]
 ----
-curl -X POST http://localhost:2480/api/v1/server \
-     -d '{ "command": "create database mydatabase" }' \
-     -H "Content-Type: application/json" \
-     --user root:arcadedb-password
+$ curl -X POST http://localhost:2480/api/v1/server \
+       -d '{ "command": "create database mydatabase" }' \
+       -H "Content-Type: application/json" \
+       --user root:arcadedb-password
 ----
 
 Return:
@@ -316,10 +316,10 @@ Return:
 
 [source,shell]
 ----
-curl -X POST http://localhost:2480/api/v1/server \
-     -d '{ "command": "drop database mydatabase" }' \
-     -H "Content-Type: application/json" \
-     --user root:arcadedb-password
+$ curl -X POST http://localhost:2480/api/v1/server \
+       -d '{ "command": "drop database mydatabase" }' \
+       -H "Content-Type: application/json" \
+       --user root:arcadedb-password
 ----
 
 Return:
@@ -334,10 +334,10 @@ Return:
 
 [source,shell]
 ----
-curl -X POST http://localhost:2480/api/v1/server \
-     -d '{ "command": "open database mydatabase" }' \
-     -H "Content-Type: application/json" \
-     --user root:arcadedb-password
+$ curl -X POST http://localhost:2480/api/v1/server \
+       -d '{ "command": "open database mydatabase" }' \
+       -H "Content-Type: application/json" \
+       --user root:arcadedb-password
 ----
 
 Return:
@@ -352,10 +352,10 @@ Return:
 
 [source,shell]
 ----
-curl -X POST http://localhost:2480/api/v1/server \
-     -d '{ "command": "close database mydatabase" }' \
-     -H "Content-Type: application/json" \
-     --user root:arcadedb-password
+$ curl -X POST http://localhost:2480/api/v1/server \
+       -d '{ "command": "close database mydatabase" }' \
+       -H "Content-Type: application/json" \
+       --user root:arcadedb-password
 ----
 
 Return:
@@ -370,10 +370,10 @@ Return:
 
 [source,shell]
 ----
-curl -X POST http://localhost:2480/api/v1/server \
-     -d '{ "command": "create user { \"name\": \"myuser\", \"password\": \"mypassword\", \"databases\": { \"mydatabase\": \"admin\" } }" }' \
-     -H "Content-Type: application/json" \
-     --user root:arcadedb-password
+$ curl -X POST http://localhost:2480/api/v1/server \
+       -d '{ "command": "create user { \"name\": \"myuser\", \"password\": \"mypassword\", \"databases\": { \"mydatabase\": \"admin\" } }" }' \
+       -H "Content-Type: application/json" \
+       --user root:arcadedb-password
 ----
 
 Return:
@@ -388,10 +388,10 @@ Return:
 
 [source,shell]
 ----
-curl -X POST http://localhost:2480/api/v1/server \
-     -d '{ "command": "drop user myuser" }' \
-     -H "Content-Type: application/json" \
-     --user root:arcadedb-password
+$ curl -X POST http://localhost:2480/api/v1/server \
+       -d '{ "command": "drop user myuser" }' \
+       -H "Content-Type: application/json" \
+       --user root:arcadedb-password
 ----
 
 Return:
@@ -406,10 +406,10 @@ Return:
 
 [source,shell]
 ----
-curl -X POST http://localhost:2480/api/v1/server \
-     -d '{ "command": "shutdown" }' \
-     -H "Content-Type: application/json" \
-     --user root:arcadedb-password
+$ curl -X POST http://localhost:2480/api/v1/server \
+       -d '{ "command": "shutdown" }' \
+       -H "Content-Type: application/json" \
+       --user root:arcadedb-password
 ----
 
 Return:
@@ -424,10 +424,10 @@ Return:
 
 [source,shell]
 ----
-curl -X POST http://localhost:2480/api/v1/server \
-     -d '{ "command": "get server events" }' \
-     -H "Content-Type: application/json" \
-     --user root:arcadedb-password
+$ curl -X POST http://localhost:2480/api/v1/server \
+       -d '{ "command": "get server events" }' \
+       -H "Content-Type: application/json" \
+       --user root:arcadedb-password
 ----
 
 Return:
@@ -442,10 +442,10 @@ Return:
 
 [source,shell]
 ----
-curl -X POST http://localhost:2480/api/v1/server \
-     -d '{ "command": "set server setting arcadedb.server.name player0" }' \
-     -H "Content-Type: application/json" \
-     --user root:arcadedb-password
+$ curl -X POST http://localhost:2480/api/v1/server \
+       -d '{ "command": "set server setting arcadedb.server.name player0" }' \
+       -H "Content-Type: application/json" \
+       --user root:arcadedb-password
 ----
 
 Return:
@@ -460,10 +460,10 @@ Return:
 
 [source,shell]
 ----
-curl -X POST http://localhost:2480/api/v1/server \
-     -d '{ "command": "set database setting mydb arcadedb.flushOnlyAtClose true" }' \
-     -H "Content-Type: application/json" \
-     --user root:arcadedb-password
+$ curl -X POST http://localhost:2480/api/v1/server \
+       -d '{ "command": "set database setting mydb arcadedb.flushOnlyAtClose true" }' \
+       -H "Content-Type: application/json" \
+       --user root:arcadedb-password
 ----
 
 Return:
@@ -478,10 +478,10 @@ Return:
 
 [source,shell]
 ----
-curl -X POST http://localhost:2480/api/v1/server \
-     -d '{ "command": "connect cluster 192.168.0.1" }' \
-     -H "Content-Type: application/json" \
-     --user root:arcadedb-password
+$ curl -X POST http://localhost:2480/api/v1/server \
+       -d '{ "command": "connect cluster 192.168.0.1" }' \
+       -H "Content-Type: application/json" \
+       --user root:arcadedb-password
 ----
 
 Return:
@@ -496,10 +496,10 @@ Return:
 
 [source,shell]
 ----
-curl -X POST http://localhost:2480/api/v1/server \
-     -d '{ "command": "disconnect cluster" }' \
-     -H "Content-Type: application/json" \
-     --user root:arcadedb-password
+$ curl -X POST http://localhost:2480/api/v1/server \
+       -d '{ "command": "disconnect cluster" }' \
+       -H "Content-Type: application/json" \
+       --user root:arcadedb-password
 ----
 
 Return:
@@ -514,10 +514,10 @@ Return:
 
 [source,shell]
 ----
-curl -X POST http://localhost:2480/api/v1/server \
-     -d '{ "command": "align database mydb" }' \
-     -H "Content-Type: application/json" \
-     --user root:arcadedb-password
+$ curl -X POST http://localhost:2480/api/v1/server \
+       -d '{ "command": "align database mydb" }' \
+       -H "Content-Type: application/json" \
+       --user root:arcadedb-password
 ----
 
 Return:
@@ -544,8 +544,8 @@ Example:
 
 [source,shell]
 ----
-curl -X GET http://localhost:2480/api/v1/databases \
-     --user root:arcadedb-password
+$ curl -X GET http://localhost:2480/api/v1/databases \
+       --user root:arcadedb-password
 ----
 
 Return:
@@ -572,8 +572,8 @@ Example:
 
 [source,shell]
 ----
-curl -X GET http://localhost:2480/api/v1/exists/school \
-     --user root:arcadedb-password
+$ curl -X GET http://localhost:2480/api/v1/exists/school \
+       --user root:arcadedb-password
 ----
 
 Return:
@@ -624,18 +624,18 @@ Example:
 
 [source,shell]
 ----
-curl -X GET http://localhost:2480/api/v1/query/school/sql/select%20from%20Class \
-     --user root:arcadedb-password
+$ curl -X GET http://localhost:2480/api/v1/query/school/sql/select%20from%20Class \
+       --user root:arcadedb-password
 ----
 
 The `query` endpoint may also be used via the POST method, which has no character restrictions such as `/` or `?`:
 
 [source,shell]
 ----
-curl -X POST http://localhost:2480/api/v1/query/school \
-     -d '{ "language": "sql", "command": "select from Class" }' \
-     -H "Content-Type: application/json" \
-     --user root:arcadedb-password
+$ curl -X POST http://localhost:2480/api/v1/query/school \
+       -d '{ "language": "sql", "command": "select from Class" }' \
+       -H "Content-Type: application/json" \
+       --user root:arcadedb-password
 ----
 
 [discrete]
@@ -654,10 +654,10 @@ Example to create the new document type "Class":
 
 [source,shell]
 ----
-curl -X POST http://localhost:2480/api/v1/command/school \
-     -d '{ "language": "sql", "command": "create document type Class"}' \
-     -H "Content-Type: application/json" \
-     --user root:arcadedb-password
+$ curl -X POST http://localhost:2480/api/v1/command/school \
+       -d '{ "language": "sql", "command": "create document type Class"}' \
+       -H "Content-Type: application/json" \
+       --user root:arcadedb-password
 ----
 
 The payload, as a JSON, accepts the following parameters:
@@ -684,10 +684,10 @@ Example of insertion of a new Client by using parameters:
 
 [source,shell]
 ----
-curl -X POST http://localhost:2480/api/v1/command/company \
-     -d '{ "language": "sql", "command": "create vertex Client set firstName = :firstName, lastName = :lastName", params: { "firstName": "Jay", "lastName": "Miner" } }' \
-     -H "Content-Type: application/json" \
-     --user root:arcadedb-password
+$ curl -X POST http://localhost:2480/api/v1/command/company \
+       -d '{ "language": "sql", "command": "create vertex Client set firstName = :firstName, lastName =  :lastName", params: { "firstName": "Jay", "lastName": "Miner" } }' \
+       -H "Content-Type: application/json" \
+       --user root:arcadedb-password
 ----
 
 [discrete]
@@ -721,8 +721,8 @@ Example:
 
 [source,shell]
 ----
-curl -I -X POST http://localhost:2480/api/v1/begin/school \
-     --user root:arcadedb-password
+$ curl -I -X POST http://localhost:2480/api/v1/begin/school \
+       --user root:arcadedb-password
 ----
 
 Returns the Session Id in the response header, example:
@@ -759,9 +759,9 @@ Example:
 
 [source,shell]
 ----
-curl -I -X POST http://localhost:2480/api/v1/commit/school \
-     -H "arcadedb-session-id: AS-ee056170-dc9b-4956-8d71-d7cfa01900d4" \
-     --user root:arcadedb-password
+$ curl -I -X POST http://localhost:2480/api/v1/commit/school \
+       -H "arcadedb-session-id: AS-ee056170-dc9b-4956-8d71-d7cfa01900d4" \
+       --user root:arcadedb-password
 ----
 
 [discrete]
@@ -791,7 +791,7 @@ Example:
 
 [source,shell]
 ----
-curl -I -X POST http://localhost:2480/api/v1/rollback/school \
-     -H "arcadedb-session-id: AS-ee056170-dc9b-4956-8d71-d7cfa01900d4" \
-     --user root:arcadedb-password
+$ curl -I -X POST http://localhost:2480/api/v1/rollback/school \
+       -H "arcadedb-session-id: AS-ee056170-dc9b-4956-8d71-d7cfa01900d4" \
+       --user root:arcadedb-password
 ----

--- a/src/main/asciidoc/api/java-api-remote.adoc
+++ b/src/main/asciidoc/api/java-api-remote.adoc
@@ -26,7 +26,14 @@ There are 2 main classes that handle the connection to the remote database by tr
 - `<<RemoteServer,RemoteServer>>`, to create new database on a remote server
 - `<<RemoteDatabase,RemoteDatabase>>`, to work with a remote database instance
 
-Let's create a RemoteDatabase instance pointing to the database "mydb" on ArcadeDB Server located on "localhost", port 5432. User and passwords are respectively "root" and "playwithdata":
+We start by creating a RemoteServer:
+
+[source,java]
+----
+RemoteServer server = new RemoteServer("localhost", 5432, "root", "playwithdata");
+----
+
+Next, let's create a RemoteDatabase instance pointing to the database "mydb" on ArcadeDB Server located on "localhost", port 5432. User and passwords are respectively "root" and "playwithdata":
 
 [source,java]
 ----
@@ -35,20 +42,19 @@ RemoteDatabase database = new RemoteDatabase("localhost", 5432, "mydb", "root", 
 
 NOTE: The `RemoteDatabase` is not thread-safe. It holds a backend session. If a thread closes a transaction, it also closes the session, so that any request performed by a concurrent thread using the same RemoteDatabase instance leads to unexpected behavior. To avoid concurrency problems you should not hold RemoteDatabase instances as fields on the heap, but rather create a new instance in method scope as a variable on the stack.
 
-The database, which name you have given as the third parameter in the constructor is not automatically created nor is it checked whether it exists. Before you use the `RemoteDatabase` make sure that the database exists, or, if it doesn't, create it.
+The database, which name you have given as the third parameter in the constructor is not automatically created nor is it checked whether it exists. Before you use the `RemoteDatabase` make sure that the database exists, or, if it doesn't, create it:
 
 [source,java]
 ----
-if (!database.exists()) {
-    database.create();
-}
+if (!server.exists("mydb"))
+    server.create();
 ----
 
 For a list of all databases hosted by the server use:
 
 [source,java]
 ----
-List<String> databases = database.databases();
+List<String> databases = server.databases();
 assert(databases.contains("mydb"));
 ----
 

--- a/src/main/asciidoc/appendix/settings.adoc
+++ b/src/main/asciidoc/appendix/settings.adoc
@@ -22,20 +22,20 @@ All the settings modified at JVM startup are not persistent and need to be set e
 If you're updating a setting at JVM level, prefix the setting name with `arcadedb.` by using this syntax:
 
 ```shell
-java ... -Darcadedb.<name>=<value> ...
+$ java ... -Darcadedb.<name>=<value> ...
 ```
 
 Where `<name>` is the name of the setting and `<value>` the value you want to override.
 Example to change the server mode from development (default) to production:
 
 ```shell
-java ... -Darcadedb.server.mode=production ...
+$ java ... -Darcadedb.server.mode=production ...
 ```
 
 Example to increase the default page size for buckets to 1 MB:
 
 ```shell
-java ... -Darcadedb.bucketDefaultPageSize=1048576 ...
+$ java ... -Darcadedb.bucketDefaultPageSize=1048576 ...
 ```
 
 Alternatively, these settings can be set via the environment variable `JAVA_OPTS`:

--- a/src/main/asciidoc/concepts/basics.adoc
+++ b/src/main/asciidoc/concepts/basics.adoc
@@ -146,7 +146,7 @@ You can query all invoices using the type as a target with the <<SQL-Select,`SEL
 
 [source,sql]
 ----
-arcadeDB> SELECT FROM Invoice
+SELECT FROM Invoice
 ----
 
 In addition to this, you can filter the result set by the year.
@@ -154,15 +154,16 @@ The type `Invoice` includes a `year` field, you can filter it through the <<Filt
 
 [source,sql]
 ----
-arcadeDB> SELECT FROM Invoice WHERE year = 2016
+SELECT FROM Invoice WHERE year = 2016
 ----
 
 You can also query specific records from a single bucket.
 By splitting the type `Invoice` across multiple buckets, (that is, one per year in our example), you can optimize the query by narrowing the potential result set.
 
-```sql
-arcadeDB> SELECT FROM BUCKET:Invoice_2016
-```
+[source,sql]
+----
+SELECT FROM BUCKET:Invoice_2016
+----
 
 By using the explicit bucket instead of the logical type, this query runs significantly faster, because ArcadeDB can narrow the search to the targeted bucket.
 No index is needed on the year, because all the invoices for year 2016 will be stored in the bucket `Invoice_2016` by the application.
@@ -192,7 +193,7 @@ If you're using SQL, this is the way you can insert a new customer into a specif
 
 [source,sql]
 ----
-arcadeDB> INSERT INTO BUCKET:Customer_Europe CONTENT { firstName: 'Enzo', lastName: 'Ferrari' }
+INSERT INTO BUCKET:Customer_Europe CONTENT { firstName: 'Enzo', lastName: 'Ferrari' }
 ----
 
 Since a bucket can only be part of one type, when you use the bucket notation with SQL, the type is inferred from the bucket, "Customer" in this case.
@@ -201,7 +202,7 @@ When you're looking for customers based in Europe, you could execute this query:
 
 [source,sql]
 ----
-arcadeDB> SELECT FROM BUCKET:Customer_Europe
+SELECT FROM BUCKET:Customer_Europe
 ----
 
 You can go even more specific by creating a bucket per country, not just for continent, and query from that bucket.
@@ -217,7 +218,7 @@ Now get all the customers that live in Italy.
 
 [source,sql]
 ----
-arcadeDB> SELECT FROM BUCKET:Customer_Europe_Italy
+SELECT FROM BUCKET:Customer_Europe_Italy
 ----
 
 You can also specify a list of buckets in your query.
@@ -225,7 +226,7 @@ This is the query to retrieve both Italian and Spanish customers.
 
 [source,sql]
 ----
-arcadeDB> SELECT FROM BUCKET:[Customer_Europe_Italy,Customer_Europe_Spain]
+SELECT FROM BUCKET:[Customer_Europe_Italy,Customer_Europe_Spain]
 ----
 
 [[Relationships]]
@@ -260,7 +261,7 @@ Example
 
 ```
     Record A -------------> Record B
- TYPE=Customer            TYPE=Invoice
+  TYPE=Customer           TYPE=Invoice
     RID #5:23               RID #10:2
 ```
 
@@ -283,17 +284,18 @@ For example,
 
 ```
     Record A <>----------> Record B
-   TYPE=Account          TYPE=Address
-    RID #5:23               NO RID
+  TYPE=Account           TYPE=Address
+    RID #5:23              NO RID
 ```
 
 Here, record `A` contains the entirety of record `B` in the property `address`.
 You can reach record `B` only by traversing the container record.
 For example,
 
-```
-arcadeDB> SELECT FROM Account WHERE address.city = 'Rome'
-```
+[source,sql]
+----
+SELECT FROM Account WHERE address.city = 'Rome'
+----
 
 [discrete]
 ==== 1:1 and n:1 Embedded Relationships
@@ -322,11 +324,12 @@ ArcadeDB supports edge constraints, which means limiting the admissible vertex t
 To this end the implicit metadata properties `@in` and `@out` need to be made explicit by creating them.
 For example, for an edge type `HasParts` that is supposed to connect only from vertices of type `Product` to vertices of type `Component`, this can be schemed by:
 
-```sql
+[source,sql]
+----
 CREATE EDGE TYPE HasParts;
 CREATE PROPERTY HasParts.`@out` link OF Product;
 CREATE PROPERTY HasParts.`@in` link OF Component;
-```
+----
 
 [discrete]
 ==== Relationship Traversal Complexity

--- a/src/main/asciidoc/concepts/basics.adoc
+++ b/src/main/asciidoc/concepts/basics.adoc
@@ -85,10 +85,11 @@ the rounded down quotient of record position and maximum records per page yields
 and the remainder gives the position on the page (here `⌊1000000 % 2048⌋`).
 In pseudo-code this computation is given by:
 
-```
+[source,java]
+----
 int pageId = floor(rid.getPosition() / maxRecordsInPage);
 int positionInPage = floor(rid.getPosition() % maxRecordsInPage);
-```
+----
 
 [[Types]]
 === Types
@@ -243,11 +244,13 @@ This is graph model's natural way of relationsships and traversable by the SQL, 
 
 Example
 
-```
+.Graph Connection
+[ditaa,graph-connection]
+....
     Vertex A -------------> Edge X -------------> Vertex B
- TYPE=Customer           TYPE=isBilled          TYPE=Invoice
-    RID #5:23              RID #16:9              RID #10:2
-```
+  TYPE Customer          TYPE isBilled          TYPE Invoice
+    RID #5꞉23               RID #16꞉9             RID #10꞉2
+....
 
 In ArcadeDB's SQL, edges are created via the <<SQL-Create-Edge,`CREATE EDGE`>> command.
 
@@ -259,11 +262,13 @@ ArcadeDB manages relationships natively without computing a `JOIN` but storing a
 
 Example
 
-```
+.Referenced Relationship
+[ditaa,referenced-relationship]
+....
     Record A -------------> Record B
-  TYPE=Customer           TYPE=Invoice
-    RID #5:23               RID #10:2
-```
+  TYPE Customer           TYPE Invoice
+    RID #5꞉23               RID #10꞉2
+....
 
 Note, that referenced relationships differ from edges:
 references are properties connecting any record while edges are types connecting vertices,
@@ -282,11 +287,13 @@ It is only accessible through the container record.
 In the event that you delete the container record, the embedded record is also deleted.
 For example,
 
-```
+.Embedded Relationship
+[ditaa,embedded-relationship]
+....
     Record A <>----------> Record B
-  TYPE=Account           TYPE=Address
-    RID #5:23              NO RID
-```
+  TYPE Account           TYPE Address
+    RID #5꞉23              NO RID
+....
 
 Here, record `A` contains the entirety of record `B` in the property `address`.
 You can reach record `B` only by traversing the container record.

--- a/src/main/asciidoc/concepts/inheritance.adoc
+++ b/src/main/asciidoc/concepts/inheritance.adoc
@@ -38,14 +38,15 @@ This query returns all instances of the types `Account` and `Company` that have 
 
 Consider an example, where you have three types, listed here with the bucket identifier in the parentheses.
 
-[source]
-----
-Account(10) <|--- Company (13) <|--- OrientTechnologiesGroup (27)
-----
+.Inheritance
+[ditaa,inheritance]
+....
+Account(10) <--- Company (13) <--- ArcadeData (27)
+....
 
 By default, ArcadeDB creates a separate bucket for each type.
-It indicates this bucket by the `defaultBucketId` property in the type `OType` and indicates the bucket used by default when not specified.
-However, the type `OType` has a property `bucketIds`, (as `int[]`), that contains all the buckets able to contain the records of that type.  `bucketIds` and `defaultBucketId` are the same by default.
+It indicates this bucket by the `defaultBucketId` property in a type and indicates the bucket used by default when not specified.
+However, a type has a property `bucketIds`, (as `int[]`), that contains all the buckets able to contain the records of that type. The properties `bucketIds` and `defaultBucketId` are the same by default.
 
 When you execute a query against a type, ArcadeDB limits the result-sets to only the records of the buckets contained in the `bucketIds` property.
 For example,

--- a/src/main/asciidoc/server/docker.adoc
+++ b/src/main/asciidoc/server/docker.adoc
@@ -6,7 +6,7 @@ To run the ArcadeDB server with Docker, type this (replace <password> with the r
 
 [source,shell]
 ----
-~/arcadedb $ docker run --rm -p 2480:2480 -p 2424:2424 --name my_arcadedb \
+$ docker run --rm -p 2480:2480 -p 2424:2424 --name my_arcadedb \
              --env JAVA_OPTS="-Darcadedb.server.rootPassword=playwithdata" \
              --hostname my_arcadedb arcadedata/arcadedb:latest
 ----
@@ -17,7 +17,7 @@ To run the console from the container started above, use:
 
 [source,shell,subs="+attributes"]
 ----
-~/arcadedb $ docker exec -it my_arcadedb bin/console.sh
+$ docker exec -it my_arcadedb bin/console.sh
 ArcadeDB Console v.23.9.1 - Copyrights (c) 2023 Arcade Data (https://arcadedb.com)
 
 >
@@ -35,8 +35,8 @@ Example of running ArcadeDB Server with all the plugins enabled (Redis, Postgres
 
 [source,shell]
 ----
-docker run --rm  -p 2480:2480 -p 2424:2424 -p 6379:6379 -p 5432:5432 -p 8182:8182 \
-           --env JAVA_OPTS="-Darcadedb.server.rootPassword=playwithdata \
+$ docker run --rm  -p 2480:2480 -p 2424:2424 -p 6379:6379 -p 5432:5432 -p 8182:8182 \
+             --env JAVA_OPTS="-Darcadedb.server.rootPassword=playwithdata \
 -Darcadedb.server.defaultDatabases=Imported[root]{import:https://github.com/ArcadeData/arcadedb-datasets/raw/main/orientdb/OpenBeer.gz} \
 -Darcadedb.server.plugins=Redis:com.arcadedb.redis.RedisProtocolPlugin,MongoDB:com.arcadedb.mongo.MongoDBProtocolPlugin,Postgres:com.arcadedb.postgres.PostgresProtocolPlugin,GremlinServer:com.arcadedb.server.gremlin.GremlinServerPlugin " \
        arcadedata/arcadedb:latest
@@ -91,12 +91,12 @@ To run ArcadeDB with 1G docker container, you could start ArcadeDB by using 800M
 
 [source,shell]
 ----
-docker ... -e ARCADEDB_OPTS_MEMORY="-Xms800M -Xmx800M" ...
+$ docker ... -e ARCADEDB_OPTS_MEMORY="-Xms800M -Xmx800M" ...
 ----
 
 To run ArcadeDB with RAM <800M, it's suggested to tune some settings. You can use the `low-ram` profile to use the least memory possible.
 
 [source,shell]
 ----
-docker ... -e ARCADEDB_OPTS_MEMORY="-Xms800M -Xmx800M" -e arcadedb.profile=low-ram ...
+$ docker ... -e ARCADEDB_OPTS_MEMORY="-Xms800M -Xmx800M" -e arcadedb.profile=low-ram ...
 ----

--- a/src/main/asciidoc/server/embed-server.adoc
+++ b/src/main/asciidoc/server/embed-server.adoc
@@ -28,33 +28,37 @@ If you're using Maven or Gradle it will be imported automatically as a dependenc
 
 To start a server as <<Embedded-Server,embedded>>, create it with an empty configuration, so all the setting will be the default ones:
 
-```java
+[source,java]
+----
 ContextConfiguration config = new ContextConfiguration();
 ArcadeDBServer server = new ArcadeDBServer(config);
 server.start();
-```
+----
 
 To start a server in distributed configuration (with replicas), you can set your settings in the `ContextConfiguration`:
 
-```java
+[source,java]
+----
 config.setValue(GlobalConfiguration.HA_SERVER_LIST, "192.168.10.1,192.168.10.2,192.168.10.3");
 config.setValue(GlobalConfiguration.HA_REPLICATION_INCOMING_HOST, "0.0.0.0");
 config.setValue(GlobalConfiguration.HA_ENABLED, true);
-```
+----
 
 When you embed the server, you should always get the database instance from the server itself.
 This assures the database instance is just one in the entire JVM.
 If you try to create or open another database instance from the `DatabaseFactory`, you will receive an error that the underlying database is locked by another process.
 
-```java
+[source,java]
+----
 Database database = server.getDatabase(<URL>);
-```
+----
 
 Or this if you want to create a new database if not exists:
 
-```java
+[source,java]
+----
 Database database = server.getOrCreateDatabase(<URL>);
-```
+----
 
 [[Custom-HTTP]]
 ==== Create custom HTTP commands
@@ -62,7 +66,8 @@ Database database = server.getOrCreateDatabase(<URL>);
 You can easily add custom HTTP commands on ArcadeDB's Undertow HTTP Server by creating a <<Server-Plugin,Server Plugin>> (look at `MongoDBProtocolPlugin` plugin implementation for a real example) and implementing the `registerAPI` method.
 Example for the HTTP POST API `/myapi/test`:
 
-```java
+[source,java]
+----
 package com.yourpackage;
 
 public class MyTest implements ServerPlugin {
@@ -77,7 +82,7 @@ public class MyTest implements ServerPlugin {
     );
   }
 }
-```
+----
 
 You can use `GET`, `POST` or any HTTP methods when you register your handler.
 Note that multiple handlers are defined under the same prefix `/myapi`.
@@ -85,7 +90,8 @@ Below you can find the implementation of the Test handler that will called by us
 Note that the `MyTestAPI` class is inheriting `DatabaseAbstractHandler` to have the database instance as a parameter.
 If the user is not authenticated, the `execute()` method is not called at all, but an authentication error is returned. If you don't need to access to the database, then you can extend the `AbstractHandler` class instead.
 
-```java
+[source,java]
+----
 public class MyTestAPI extends DatabaseAbstractHandler {
 
   public MyTestAPI(final HttpServer httpServer) {
@@ -110,8 +116,7 @@ public class MyTestAPI extends DatabaseAbstractHandler {
     exchange.getResponseSender().send("");
   }
 }
-
-```
+----
 
 At startup, ArcadeDB Server will initiate your plugin and register your API.
 To start the server with your plugin, register the full class in
@@ -119,21 +124,23 @@ To start the server with your plugin, register the full class in
 
 Example:
 
-```
-java ... -Darcadedb.server.plugins=MyPlugin:com.yourpackage.MyPlugin ...
-```
+[source,shell]
+----
+$ java ... -Darcadedb.server.plugins=MyPlugin:com.yourpackage.MyPlugin ...
+----
 
 ==== HTTPS connection
 
 In order to enable HTTPS on ArcadeDB server, you have to set the following configuration before the server starts:
 
-```java
+[source,java]
+----
 configuration.setValue(GlobalConfiguration.NETWORK_USE_SSL, true);
 configuration.setValue(GlobalConfiguration.NETWORK_SSL_KEYSTORE, "src/test/resources/master.jks");
 configuration.setValue(GlobalConfiguration.NETWORK_SSL_KEYSTORE_PASSWORD, "keypassword");
 configuration.setValue(GlobalConfiguration.NETWORK_SSL_TRUSTSTORE, "src/test/resources/master.jks");
 configuration.setValue(GlobalConfiguration.NETWORK_SSL_TRUSTSTORE_PASSWORD, "storepassword");
-```
+----
 
 Where:
 
@@ -145,9 +152,10 @@ Where:
 
 Note that the default port for HTTPs is configured under the new global setting:
 
-```java
+[source,java]
+----
 GlobalConfiguration.SERVER_HTTPS_INCOMING_PORT
-```
+----
 
 And by default starts from 2490 to 2499 (increases the port if it's already occupied).
 

--- a/src/main/asciidoc/server/ha.adoc
+++ b/src/main/asciidoc/server/ha.adoc
@@ -17,15 +17,17 @@ If not specified, the default server name is "ArcadeDB_0"
 
 Example:
 
-```shell
+[source,shell]
+----
 $ bin/server.sh -Darcadedb.ha.enabled=true
                 -Darcadedb.server.name=FloridaServer
                 -Darcadedb.ha.serverList=192.168.0.2,192.168.0.1:2424,japan-server:8888
-```
+----
 
 The log should look like this:
 
-```shell
+[source,shell]
+----
 [HttpServer] <FloridaServer> - HTTP Server started (host=0.0.0.0 port=2480)
 [LeaderNetworkListener] <ArcadeDB_0> Listening for replication connections on 127.0.0.1:2424 (protocol v.-1)
 [HAServer] <FloridaServer> Unable to find any Leader, start election (cluster=arcadedb configuredServers=1 majorityOfVotes=1)
@@ -34,7 +36,7 @@ The log should look like this:
 [HAServer] <FloridaServer> Current server elected as new Leader (turn=1 totalVotes=1 majority=1)
 [HAServer] <FloridaServer> Change election status from VOTING_FOR_ME to LEADER_WAITING_FOR_QUORUM
 [HAServer] <FloridaServer> Contacting all the servers for the new leadership (turn=1)...
-```
+----
 
 At startup, the ArcadeDB server will look for an existent cluster to join based on the configured list of servers, otherwise a new cluster will be created.
 In this example we set the server name to `FloridaServer`.
@@ -151,17 +153,19 @@ More coming soon.
 ArcadeDB uses an optimistic lock approach: if two threads try to update the same page, the first thread wins, the second thread throws a `ConcurrentModificationException` and forces the client to retry the transaction or fail after a certain number of retries (configurable).
 Often this fail/retry mechanism is totally hidden to the developer that executes a transaction via HTTP or via the Java API:
 
-```java
+[source,java]
+----
 db.transaction( ()-> {
   // MY TRANSACTION CODE
 });
-```
+----
 
-If you are inserting a lot of record in parallel (by using the Server, or just via API multi-thread), you could benefit by allocating the bucket per thread. Example to change the bucket selection strategy for the vertex type "User":
+If you are inserting a lot of record in parallel (by using the Server, or just via API multi-thread), you could benefit by allocating the bucket per thread. Example to change the bucket selection strategy for the vertex type "User" via SQL:
 
-```sql
-alter type User BucketSelectionStrategy `thread`
-```
+[source,sql]
+----
+> ALTER TYPE User BucketSelectionStrategy `thread`
+----
 
 With the command above, in insertion ArcadeDB will select the physical bucket based on the thread the request is coming from. If you have enough buckets (created by default when you create a new type, but you can manually adjust it) insertions can go truly in parallel with zero contentions in pages, meaning zero exception and retries.
 

--- a/src/main/asciidoc/server/kubernetes.adoc
+++ b/src/main/asciidoc/server/kubernetes.adoc
@@ -7,7 +7,7 @@ image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/
 Before starting the cluster, set ArcadeDB Server root password as a secret (replace <password> with the root password you want to use):
 
 ```shell
-~/arcadedb $ kubectl create secret generic arcadedb-credentials --from-literal=rootPassword='<password>'
+$ kubectl create secret generic arcadedb-credentials --from-literal=rootPassword='<password>'
 ```
 
 This will set the password in the `rootPassword` environment variable. The ArcadeDB server will use this password for the `root` user.
@@ -15,7 +15,7 @@ This will set the password in the `rootPassword` environment variable. The Arcad
 Now you can start a Kubernetes cluster with 3 servers by using the default configuration:
 
 ```shell
-~/arcadedb $ kubectl apply -f config/arcadedb-statefulset.yaml
+$ kubectl apply -f config/arcadedb-statefulset.yaml
 ```
 
 For more information on ArcadeDB Kubernetes config https://github.com/ArcadeData/arcadedb/blob/main/package/src/main/config/arcadedb-statefulset.yaml[please check].
@@ -23,13 +23,13 @@ For more information on ArcadeDB Kubernetes config https://github.com/ArcadeData
 In order to scale up or down with the number of replicas, use this:
 
 ```shell
-~/arcadedb $ kubectl scale statefulsets arcadedb-server --replicas=<new-number-of-replicas>
+$ kubectl scale statefulsets arcadedb-server --replicas=<new-number-of-replicas>
 ```
 
 Where the value of `<new-number-of-replicas>` is the new number of replicas. Example:
 
 ```shell
-~/arcadedb $ kubectl scale statefulsets arcadedb-server --replicas=3
+$ kubectl scale statefulsets arcadedb-server --replicas=3
 ```
 
 Scaling up and down doesn't affect current workload. There are no pauses when a server enters/exits from the cluster.
@@ -43,7 +43,7 @@ Follows some useful commands for troubleshooting issues with ArcadeDB and Kubern
 Display the status of a pod:
 
 ```shell
-~/arcadedb $ kubectl describe pod arcadedb-0
+$ kubectl describe pod arcadedb-0
 ```
 
 Replace "arcadedb-0" with the server container you want to use.
@@ -51,7 +51,7 @@ Replace "arcadedb-0" with the server container you want to use.
 To display the logs of the first server:
 
 ```shell
-~/arcadedb $ kubectl logs arcadedb-0
+$ kubectl logs arcadedb-0
 ```
 
 Replace "arcadedb-0" with the server container you want to use.
@@ -59,7 +59,6 @@ Replace "arcadedb-0" with the server container you want to use.
 To remove all the containers and restart the cluster again, execute these 2 commands:
 
 ```shell
-~/arcadedb $ kubectl delete all --all --namespace default
-~/arcadedb $ kubectl apply -f config/arcadedb-statefulset.yaml
+$ kubectl delete all --all --namespace default
+$ kubectl apply -f config/arcadedb-statefulset.yaml
 ```
-

--- a/src/main/asciidoc/server/kubernetes.adoc
+++ b/src/main/asciidoc/server/kubernetes.adoc
@@ -6,31 +6,35 @@ image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/
 
 Before starting the cluster, set ArcadeDB Server root password as a secret (replace <password> with the root password you want to use):
 
-```shell
+[source,shell]
+----
 $ kubectl create secret generic arcadedb-credentials --from-literal=rootPassword='<password>'
-```
+----
 
 This will set the password in the `rootPassword` environment variable. The ArcadeDB server will use this password for the `root` user.
 
 Now you can start a Kubernetes cluster with 3 servers by using the default configuration:
 
-```shell
+[source,shell]
+----
 $ kubectl apply -f config/arcadedb-statefulset.yaml
-```
+----
 
 For more information on ArcadeDB Kubernetes config https://github.com/ArcadeData/arcadedb/blob/main/package/src/main/config/arcadedb-statefulset.yaml[please check].
 
 In order to scale up or down with the number of replicas, use this:
 
-```shell
+[source,shell]
+----
 $ kubectl scale statefulsets arcadedb-server --replicas=<new-number-of-replicas>
-```
+----
 
 Where the value of `<new-number-of-replicas>` is the new number of replicas. Example:
 
-```shell
+[source,shell]
+----
 $ kubectl scale statefulsets arcadedb-server --replicas=3
-```
+----
 
 Scaling up and down doesn't affect current workload. There are no pauses when a server enters/exits from the cluster.
 
@@ -42,23 +46,26 @@ Follows some useful commands for troubleshooting issues with ArcadeDB and Kubern
 
 Display the status of a pod:
 
-```shell
+[source,shell]
+----
 $ kubectl describe pod arcadedb-0
-```
+----
 
 Replace "arcadedb-0" with the server container you want to use.
 
 To display the logs of the first server:
 
-```shell
+[source,shell]
+----
 $ kubectl logs arcadedb-0
-```
+----
 
 Replace "arcadedb-0" with the server container you want to use.
 
 To remove all the containers and restart the cluster again, execute these 2 commands:
 
-```shell
+[source,shell]
+----
 $ kubectl delete all --all --namespace default
 $ kubectl apply -f config/arcadedb-statefulset.yaml
-```
+----

--- a/src/main/asciidoc/server/server.adoc
+++ b/src/main/asciidoc/server/server.adoc
@@ -105,7 +105,7 @@ set the environment variable `ARCADEDB_HOME` to the ArcadeDB folder:
 
 [source,shell]
 ----
-export ARCADEDB_HOME=/path/to/arcadedb
+$ export ARCADEDB_HOME=/path/to/arcadedb
 ----
 
 ==== Server modes
@@ -185,7 +185,7 @@ If you're running ArcadeDB in <<Embedded-Server,embedded>> mode, make sure you'r
 
 [source,shell]
 ----
-java ... -Djava.util.logging.config.file=$ARCADEDB_HOME/config/arcadedb-log.properties ...
+$ java ... -Djava.util.logging.config.file=$ARCADEDB_HOME/config/arcadedb-log.properties ...
 ----
 
 You can also use your own configuration for logging. In this case replace the path above with your own file.
@@ -250,7 +250,7 @@ Example:
 
 [source,shell]
 ----
-java ... -Darcadedb.server.plugins=MyPlugin:com.yourpackage.MyPlugin ...
+$ java ... -Darcadedb.server.plugins=MyPlugin:com.yourpackage.MyPlugin ...
 ----
 
 In case of multiple plugins, use the comma to separate them.

--- a/src/main/asciidoc/server/settings.adoc
+++ b/src/main/asciidoc/server/settings.adoc
@@ -6,7 +6,7 @@ To change the default value of a setting, always put `arcadedb.` as a prefix. Ex
 
 [source,shell]
 ----
-~/arcadedb $ java -Darcadedb.dumpConfigAtStartup=true ...
+$ java -Darcadedb.dumpConfigAtStartup=true ...
 ----
 
 To change the same setting via Java code:
@@ -42,16 +42,16 @@ Example to use 800M fixed RAM for ArcadeDB Server:
 
 [source,shell]
 ----
-export ARCADEDB_OPTS_MEMORY="-Xms800M -Xmx800M"
-bin/server.sh
+$ export ARCADEDB_OPTS_MEMORY="-Xms800M -Xmx800M"
+$ bin/server.sh
 ----
 
 ArcadeDB can run with as little as 16 MB for RAM. In case you're running ArcadeDB with less than 800M of RAM, you should set the "low-ram" as profile:
 
 [source,shell]
 ----
-export ARCADEDB_OPTS_MEMORY="-Xms128M -Xmx128M"
-bin/server.sh -Darcadedb.profile=low-ram
+$ export ARCADEDB_OPTS_MEMORY="-Xms128M -Xmx128M"
+$ bin/server.sh -Darcadedb.profile=low-ram
 ----
 
 Setting a profile is like executing a macro that changes multiple settings at once. You can tune them individually, check <<Settings,Settings>>.
@@ -60,7 +60,7 @@ In case of memory latency problems under Linux systems, the following JVM settin
 
 [source,shell]
 ----
-export ARCADEDB_OPTS_MEMORY="-XX:+PerfDisableSharedMem"
+$ export ARCADEDB_OPTS_MEMORY="-XX:+PerfDisableSharedMem"
 ----
 
 for more information, see https://www.evanjones.ca/jvm-mmap-pause.html
@@ -70,7 +70,7 @@ for custom containers, memory configuration can be adapted by:
 
 [source,shell]
 ----
-export ARCADEDB_OPTS_MEMORY="-XX:InitialRAMPercentage=50.0 -XX:MaxRAMPercentage=75.0"
+$ export ARCADEDB_OPTS_MEMORY="-XX:InitialRAMPercentage=50.0 -XX:MaxRAMPercentage=75.0"
 ----
 
 More information about Java memory configuration see https://developers.redhat.com/articles/2022/04/19/java-17-whats-new-openjdks-container-awareness#[this article].

--- a/src/main/asciidoc/sql/SQL-Introduction.adoc
+++ b/src/main/asciidoc/sql/SQL-Introduction.adoc
@@ -253,3 +253,19 @@ In ArcadeDB, you can accomplish this with a few variable definitions and by usin
 ----
 SELECT expand( $c ) LET $a = ( SELECT FROM E ), $b = ( SELECT FROM V ), $c = unionall( $a, $b )
 ----
+
+*SQL Differences*
+
+Following are some basic differences between ArcadeDB and PostgreSQL.
+
+[%header,cols=2]
+|===
+| Postgres | ArcadeDB
+| `CREATE TABLE` | <<SQL-Create-Type,`CREATE TYPE`>>
+| `ALTER TABLE` | <<SQL-Alter-Type,`ALTER TYPE`>>
+| `ADD COLUMN` | <<SQL-Create-Property,`CREATE PROPERTY`>>
+| `ALTER COLUMN`  | <<SQL-Alter-Property,`ALTER PROPERTY`>>
+| `SELECT * FROM information_schema.tables` | `SELECT FROM schema:types`
+| `SELECT * FROM pg_indexes` | `SELECT FROM schema:pg_indexes`
+| `SELECT * FROM pg_database` | `SELECT FROM schema:pg_database`
+|===

--- a/src/main/asciidoc/tools/console.adoc
+++ b/src/main/asciidoc/tools/console.adoc
@@ -3,11 +3,11 @@
 === Console
 image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/tools/console.adoc" float=right]
 
-Run the console by executing `console.sh` under `bin` directory:
+Run the console by executing `console.sh` under `bin` directory from the `arcadedb` directory:
 
 [source,shell,subs="attributes+"]
 ----
-~/arcadedb $ bin/console.sh
+$ bin/console.sh
 
 ArcadeDB Console v.{revnumber} - Copyrights (c) 2021 Arcade Data Ltd (https://arcadedb.com)
 
@@ -71,7 +71,7 @@ The database directory can be explicitely set, when you start the console, like
 
 [source,shell]
 ----
-~/arcadedb $ ./bin/console.sh -Darcadedb.server.databaseDirectory=/databases
+$ ./bin/console.sh -Darcadedb.server.databaseDirectory=/databases
 ----
 
 If no database directory is given at startup, it is the `databases` directory under the root path of the arcadedb server by default.
@@ -201,21 +201,21 @@ The console can also run local SQL scripts by passing the file (path):
 
 [source,shell]
 ----
-~/arcadedb $ bin/console.sh myscript.sql
+$ bin/console.sh myscript.sql
 ----
 
 or using the `LOAD` command:
 
 [source,shell]
 ----
-~/arcadedb $ bin/console.sh "LOAD myscript.sql"
+$ bin/console.sh "LOAD myscript.sql"
 ----
 
 or passing the commands as string argument:
 
 [source,shell]
 ----
-~/arcadedb $ bin/console.sh "CREATE DATABASE test; CREATE DOCUMENT TYPE doc; BACKUP DATABASE; exit;"
+$ bin/console.sh "CREATE DATABASE test; CREATE DOCUMENT TYPE doc; BACKUP DATABASE; exit;"
 ----
 
 NOTE: Make sure to `create database` or `connect` to a database first in the script before using <<SQL,SQL commands>>.

--- a/src/main/asciidoc/tools/console.adoc
+++ b/src/main/asciidoc/tools/console.adoc
@@ -77,60 +77,63 @@ $ ./bin/console.sh -Darcadedb.server.databaseDirectory=/databases
 If no database directory is given at startup, it is the `databases` directory under the root path of the arcadedb server by default.
 To create a new database under the database directory, you would run the following command in the console
 
-[source,shell]
+[source,sql]
 ----
-> create database mydb
+> CREATE DATABASE mydb
 ----
 
 If you want to create your database somewhere else in the local filesystem, you can specify a different path to the database:
 
-[source,shell]
+[source,sql]
 ----
-> create database data/mydb
+> CREATE DATABASE data/mydb
 ----
 
 Once the database has been created, you can simply connect to it:
 
-[source,shell]
+[source,sql]
 ----
-> connect mydb
+> CONNECT mydb
 ----
 
 Or if on a different path, specify the path where the database is located:
 
-[source,shell]
+[source,sql]
 ----
-> connect data/mydb
+> CONNECT data/mydb
 ----
 
 
 If you're using the ArcadeDB Server, you can create the database through the server:
 
-[source,shell]
+[source,sql]
 ----
-> create database remote:localhost/mydb root arcadedb-password
+> CREATE DATABASE remote:localhost/mydb root arcadedb-password
 ----
 
 Once created, you can always connect to the server with the following command:
 
-[source,shell]
+[source,sql]
 ----
-> connect remote:localhost/mydb root arcadedb-password
+> CONNECT remote:localhost/mydb root arcadedb-password
 ----
 
 Let's also create a user with access to "mydb":
 
-[source,shell]
+[source,sql]
 ----
-> create user elon identified by muskmusk grant connect to mydb
+> CREATE USER elon IDENTIFIED BY muskmusk GRANT CONNECT TO mydb
 ----
 
 Now let's create a "Profile" type:
 
+[source,sql]
+----
+{mydb}> CREATE DOCUMENT TYPE Profile
+----
+
 [source]
 ----
-{mydb}> create document type Profile
-
 +---------+--------------------+
 |NAME     |VALUE               |
 +---------+--------------------+
@@ -142,10 +145,13 @@ Command executed in 99ms
 
 Check your new type is there:
 
-[source,shell]
+[source,sql]
 ----
-{mydb}> info types
+{mydb}> INFO TYPES
+----
 
+[source]
+----
 AVAILABLE TYPES
 +-------+--------+-----------+-------------------------------------+-----------+-------------+
 |NAME   |TYPE    |SUPER TYPES|BUCKETS                              |PROPERTIES |SYNC STRATEGY|
@@ -158,10 +164,13 @@ You can also query the defined types by executing the following SQL query: `sele
 
 Finally, let's create a document of type "Profile":
 
-[source,shell]
+[source,sql]
 ----
-{mydb}> insert into Profile set name = 'Jay', lastName = 'Miner'
+{mydb}> INSERT INTO Profile SET name = 'Jay', lastName = 'Miner'
+----
 
+[source]
+----
 DOCUMENT @type:Profile @rid:#1:0
 +--------+-----+
 |NAME    |VALUE|
@@ -175,10 +184,13 @@ Command executed in 17ms
 You can see your brand new record with RID `#1:0`.
 Now let's query the database to see if our new document can be found:
 
-[source,shell]
+[source,sql]
 ----
-{mydb}> select from Profile
+{mydb}> SELECT FROM Profile
+----
 
+[source]
+----
 DOCUMENT @type:Profile @rid:#1:0
 +--------+-----+
 |NAME    |VALUE|
@@ -191,7 +203,7 @@ Command executed in 37ms
 
 Here we go: our document is there.
 
-Remember that a transaction is automatically started. In order to make changes persistent, execute a `commit` command.
+Remember that a transaction is automatically started. In order to make changes persistent, execute a `COMMIT` command.
 When the console exists (`exit` or `quit` command), the pending transaction is committed automatically.
 
 [[Console-Scripting]]
@@ -232,7 +244,7 @@ hence the console cannot access these databases via local connection which utili
 Nonetheless, the console can still connect to these databases via a remote connection,
 particularly, using `localhost` if the console is running on the same machine as the server:
 
-[source,shell]
+[source,sql]
 ----
-> connect remote:localhost/mydb root arcadedb-password
+> CONNECT remote:localhost/mydb root arcadedb-password
 ----

--- a/src/main/asciidoc/tools/importer.adoc
+++ b/src/main/asciidoc/tools/importer.adoc
@@ -33,10 +33,14 @@ URLs can be local paths (use `file://`) or from the Internet by using `http://` 
 
 Example of loading the Freebase RDF dataset:
 
-```
-> create database FreeBase
-{FreeBase}> import database http://commondatastorage.googleapis.com/freebase-public/rdf/freebase-rdf-latest.gz
+[source,sql]
+----
+> CREATE DATABASE FreeBase
+{FreeBase}> IMPORT DATABASE http://commondatastorage.googleapis.com/freebase-public/rdf/freebase-rdf-latest.gz
+----
 
+[source]
+----
 Analyzing url: http://commondatastorage.googleapis.com/freebase-public/rdf/freebase-rdf-latest.gz... [SourceDiscovery]
 Recognized format RDF (limitBytes=9.54MB limitEntries=0) [SourceDiscovery]
 Creating type 'Node' of type VERTEX [Importer]
@@ -44,22 +48,24 @@ Creating type 'Relationship' of type EDGE [Importer]
 Parsed 144951 (28990/sec) - 0 documents (0/sec) - 143055 vertices (28611/sec) - 144951 edges (28990/sec) [Importer]
 Parsed 362000 (54256/sec) - 0 documents (0/sec) - 164118 vertices (5260/sec) - 362000 edges (54256/sec) [Importer]
 ...
-```
+----
 
 Example of loading the Discogs dataset in the database on path "/temp/discogs":
 
-```
-> import database https://discogs-data.s3-us-west-2.amazonaws.com/data/2018/discogs_20180901_releases.xml.gz
-```
+[source,sql]
+----
+> IMPORT DATABASE https://discogs-data.s3-us-west-2.amazonaws.com/data/2018/discogs_20180901_releases.xml.gz
+----
 
 Note that in this case the URL is `https` and the file is compressed with `GZip`.
 
 Example of importing New York Taxi dataset in CSV format.
 The first line of the CSV file set the property names:
 
-```
-> import database file:///personal/Downloads/data-society-uber-pickups-in-nyc/original/uber-raw-data-april-15.csv/uber-raw-data-april-15.csv
-```
+[source,sql]
+----
+> IMPORT DATABASE file:///personal/Downloads/data-society-uber-pickups-in-nyc/original/uber-raw-data-april-15.csv/uber-raw-data-april-15.csv
+----
 
 See also:
 
@@ -72,26 +78,28 @@ See also:
 
 The Importer takes additional settings as pairs of setting name and value. With the SQL <<SQL-Import-Database,`IMPORT DATABASE`>> command, this is the syntax:
 
-```sql
+[source,sql]
+----
 IMPORT DATABASE <url> [ WITH ( <setting-name> = <setting-value> [,] )* ]
-```
+----
 
 Example:
 
-```
-> import database file:///import/file.csv with forceDatabaseCreate = true, commitEvery = 100
-```
+[source,sql]
+----
+> IMPORT DATABASE file:///import/file.csv WITH forceDatabaseCreate = true, commitEvery = 100
+----
 
 Below you can find all the supported settings for the Importer.
 
 [%header,cols="20,20,~"]
 |===
 | Setting | Default | Description
-| url| | url of the file to import
-| database| ./databases/imported | Path of the final imported database
+| url | | url of the file to import
+| database | ./databases/imported | Path of the final imported database
 | forceDatabaseCreate|false | If true, the database is created brand new at every import
-| wal| false | Use the WAL (journal) for the importing. If the WAL is enabled the importing process will be much slower and will require much more RAM
-| commitEvery| 5000| Create transactions that commit every X records
+| wal | false | Use the WAL (journal) for the importing. If the WAL is enabled the importing process will be much slower and will require much more RAM
+| commitEvery | 5000 | Create transactions that commit every X records
 | parallel| Half of the available cores - 1. If you have 8 cores, the default is 3 | The number of concurrent threads used
 | typeIdProperty| | Property that represents the ID of the vertex
 | typeIdUnique| false | True creates a unique index on the type id property, otherwise a non unique index

--- a/src/main/asciidoc/tools/json-importer.adoc
+++ b/src/main/asciidoc/tools/json-importer.adoc
@@ -27,8 +27,8 @@ Let's start from this simple JSON file to import as an example. The file contain
 
 First, create a new database "employees" by using the console:
 
-```
-~/arcadedb $ create database employees
+```shell
+$ create database employees
 ```
 
 Then execute the following command (assuming the file above is saved in the local directory as `employees.json`:
@@ -87,7 +87,7 @@ USDA provides updated files to download in both CSV and JSON format.
 First, create a new database "food" by using the console:
 
 ```
-~/arcadedb $ create database food
+$ create database food
 ```
 
 Then execute the following command:

--- a/src/main/asciidoc/tools/json-importer.adoc
+++ b/src/main/asciidoc/tools/json-importer.adoc
@@ -27,39 +27,40 @@ Let's start from this simple JSON file to import as an example. The file contain
 
 First, create a new database "employees" by using the console:
 
-```shell
-$ create database employees
-```
+[source,sql]
+----
+> CREATE DATABASE employees
+----
 
 Then execute the following command (assuming the file above is saved in the local directory as `employees.json`:
 
-```
-import database employees.json
-with mapping = {
-    "Users": [{
-        "@cat": "v",
-        "@type": "User",
-        "@id": "id",
-        "@idType": "string",
-        "@strategy": "merge",
-        "EmployeeID": "@ignore",
-        "ManagerID": {
-            "@cat": "e",
-            "@type": "HAS_MANAGER",
-            "@cardinality": "no-duplicates",
-            "@in": {
-                "@cat": "v",
-                "@type": "User",
-                "@id": "id",
-                "@idType": "string",
-                "@strategy": "merge",
-                "EmployeeID": "@ignore",
-                "id": "<../ManagerID>"
-            }
-        }
-    }]
+[source,sql]
+----
+{employees}> IMPORT DATABASE employees.json WITH mapping = {
+	"Users": [{
+			"@cat": "v",
+			"@type": "User",
+			"@id": "id",
+			"@idType": "string",
+			"@strategy": "merge",
+			"EmployeeID": "@ignore",
+			"ManagerID": {
+					"@cat": "e",
+					"@type": "HAS_MANAGER",
+					"@cardinality": "no-duplicates",
+					"@in": {
+							"@cat": "v",
+							"@type": "User",
+							"@id": "id",
+							"@idType": "string",
+							"@strategy": "merge",
+							"EmployeeID": "@ignore",
+							"id": "<../ManagerID>"
+					}
+			}
+	}]
 }
-```
+----
 
 The mapping file is a JSON snippet with directives about what to import, what to ignore and how to map edges with JSON objects.
 Below all the supported tags:
@@ -86,15 +87,16 @@ USDA provides updated files to download in both CSV and JSON format.
 
 First, create a new database "food" by using the console:
 
-```
-$ create database food
-```
+[source,sql]
+----
+> CREATE DATABASE food
+----
 
 Then execute the following command:
 
-```
-import database https://fdc.nal.usda.gov/fdc-datasets/FoodData_Central_foundation_food_json_2022-10-28.zip
-with mapping = {
+[source,sql]
+----
+{food}> IMPORT DATABASE https://fdc.nal.usda.gov/fdc-datasets/FoodData_Central_foundation_food_json_2022-10-28.zip WITH mapping = {
 	"FoundationFoods": [{
 		"@cat": "v",
 		"@type": "<foodClass>",
@@ -139,10 +141,9 @@ with mapping = {
 		}]
 	}]
 }
-```
+----
 
 image::../images/json-import.png[align="center"]
-
 
 This command downloads the zip file from the USDA website and uses the mapping to create the graph from the JSON file.
 

--- a/src/main/asciidoc/tools/neo4j-importer.adoc
+++ b/src/main/asciidoc/tools/neo4j-importer.adoc
@@ -48,8 +48,8 @@ To import a database use the <<SQL-Import-Database,Import Database>> command fro
 
 [source,shell]
 ----
-~/arcadedb $ create database PanamaPapers
-~/arcadedb $ import database file:///temp/panama-papers-neo4j.jsonl
+$ create database PanamaPapers
+$ import database file:///temp/panama-papers-neo4j.jsonl
 
 ArcadeDB 21.9.1 - Neo4j Importer
 Importing Neo4j database from file 'panama-papers-neo4j.jsonl' to 'databases/PanamaPapers'

--- a/src/main/asciidoc/tools/neo4j-importer.adoc
+++ b/src/main/asciidoc/tools/neo4j-importer.adoc
@@ -12,9 +12,10 @@ Neo4j supports multiple labels per node, while in ArcadeDB a node (vertex) must 
 The Neo4j importer will simulate multiple labels by creating new types with the following name: `<label1>[_<labelN>]*`.
 Example:
 
-```json
+[source,json]
+----
 {"type":"node","id":"1","labels":["User", "Administrator"],"properties":{"name":"Jim","age":42}}
-```
+----
 
 This vertex will be created in ArcadeDB with type "Administrator_User" (the labels are always sorted alphabetically) that extends both "Administrator" and "User" types.
 
@@ -46,12 +47,15 @@ First all the nodes (vertices), then the relationships (edges).
 
 To import a database use the <<SQL-Import-Database,Import Database>> command from API, Studio or Console. Below you can find an example of importing the Neo4j's PanamaPapers database by using ArcadeDB <<Console,Console>>.
 
-[source,shell]
+[source,sql]
 ----
-$ create database PanamaPapers
-$ import database file:///temp/panama-papers-neo4j.jsonl
+> CREATE DATABASE PanamaPapers
+{PanamaPapers}> IMPORT DATABASE file:///temp/panama-papers-neo4j.jsonl
+----
 
-ArcadeDB 21.9.1 - Neo4j Importer
+[source,subs="attributes+"]
+----
+ArcadeDB {revnumber} - Neo4j Importer
 Importing Neo4j database from file 'panama-papers-neo4j.jsonl' to 'databases/PanamaPapers'
 Creation of the schema: types, properties and indexes
 - Creation of vertices started

--- a/src/main/asciidoc/tools/orientdb-importer.adoc
+++ b/src/main/asciidoc/tools/orientdb-importer.adoc
@@ -8,9 +8,9 @@ For more information about how to export a database from OrientDB, look at http:
 
 To import a database use the <<SQL-Import-Database,Import Database>> command from API, Studio or Console. Below you can find an example of importing a OrientDB database by using ArcadeDB <<Console,Console>>.
 
-[source,shell]
+[source,sql]
 ----
-$ create database MyDatabase
-$ import database file:///temp/orientdb-export.tgz
+> CREATE DATABASE MyDatabase
+{MyDatabase}> IMPORT DATABASE file:///temp/orientdb-export.tgz
 ----
 

--- a/src/main/asciidoc/tools/orientdb-importer.adoc
+++ b/src/main/asciidoc/tools/orientdb-importer.adoc
@@ -10,7 +10,7 @@ To import a database use the <<SQL-Import-Database,Import Database>> command fro
 
 [source,shell]
 ----
-~/arcadedb $ create database MyDatabase
-~/arcadedb $ import database file:///temp/orientdb-export.tgz
+$ create database MyDatabase
+$ import database file:///temp/orientdb-export.tgz
 ----
 

--- a/src/main/asciidoc/tools/restore.adoc
+++ b/src/main/asciidoc/tools/restore.adoc
@@ -13,8 +13,7 @@ Example for restoring the database "mydb" from the backup located in `backups/my
 
 [source,shell]
 ----
-~/arcadedb $ bin/restore.sh -f backups/mysb/mydb-backup-20210921-172750767.zip -d databases/mydb
-
+$ bin/restore.sh -f backups/mysb/mydb-backup-20210921-172750767.zip -d databases/mydb
 ----
 
 ==== Configuration


### PR DESCRIPTION
* Shell type source blocks all start with `$` (Section 3,4,6,7)
* Console source blocks all start with `>` (Section 3,4,6)
* SQL blocks use all caps commands (Section 3,4,6)
* Prepend database name in console blocks where needed (Section 6)
* Make ASCII diagrams render via ditaa (Section 3)
* Add small table comparing differences of Postgres with ArcadeDB SQL (Section 8)
* Fix https://github.com/ArcadeData/arcadedb-docs/issues/261 (Section 7.3.1)