### PR TITLE
Added information on how to add studio for embedded server.

### DIFF
--- a/src/main/asciidoc/server/embed-server.adoc
+++ b/src/main/asciidoc/server/embed-server.adoc
@@ -24,6 +24,16 @@ If you're using Maven include this dependency in your `pom.xml` file.
 This library depends on `arcadedb-network-<version>.jar`.
 If you're using Maven or Gradle it will be imported automatically as a dependency, otherwise please add also the `arcadedb-network` library to your classpath.
 
+#Note:# `arcadedb-server` dependency will only start the arcadedb server and you will see the http url for the server along with the port number. For example - `http://localhost:2480`.  If you try and access this url to see the arace db studio, you will get the message that "Not Found". This is because, `arcadedb-server` depedency only adds the embedded server. 
+If you aneed to access the arcadedb-studio to execute graphdb queries then you also need to add the the below depednecy. 
+----
+<dependency>
+    <groupId>com.arcadedb</groupId>
+    <artifactId>arcadedb-studio</artifactId>
+    <version>{revnumber}</version>
+</dependency>
+----
+
 ==== Start the server in the JVM
 
 To start a server as <<Embedded-Server,embedded>>, create it with an empty configuration, so all the setting will be the default ones:

--- a/src/main/asciidoc/server/embed-server.adoc
+++ b/src/main/asciidoc/server/embed-server.adoc
@@ -24,8 +24,8 @@ If you're using Maven include this dependency in your `pom.xml` file.
 This library depends on `arcadedb-network-<version>.jar`.
 If you're using Maven or Gradle it will be imported automatically as a dependency, otherwise please add also the `arcadedb-network` library to your classpath.
 
-#Note:# `arcadedb-server` dependency will only start the arcadedb server and you will see the http url for the server along with the port number. For example - `http://localhost:2480`.  If you try and access this url to see the arace db studio, you will get the message that "Not Found". This is because, `arcadedb-server` depedency only adds the embedded server. 
-If you aneed to access the arcadedb-studio to execute graphdb queries then you also need to add the the below depednecy. 
+#Note:# The `arcadedb-server` dependency will only start the ArcadeDB server. You will see the HTTP URL for the server along with the port number displayed, for example, `http://localhost:2480`. However, if you try to access this URL to see the ArcadeDB studio, you will receive a `"Not Found"` message. This is because the arcadedb-server dependency only adds the embedded server. 
+If you need to access the ArcadeDB studio to execute graph database queries, then you will need to add the following dependency:
 ----
 <dependency>
     <groupId>com.arcadedb</groupId>


### PR DESCRIPTION
The document talks about adding embedded server dependency but does not tell the user that the studio url will not be accessible. The arcadedb studio can be accessed after additional dependency `arcade-studio` is added. See my stackoverflow question to see more information on this - https://stackoverflow.com/questions/78329249/arcadedb-studio-when-starting-embedded-server