### PR TITLE
Various fixes and additions

### DIFF
--- a/src/main/asciidoc/api/java-api-remote.adoc
+++ b/src/main/asciidoc/api/java-api-remote.adoc
@@ -30,14 +30,14 @@ We start by creating a RemoteServer:
 
 [source,java]
 ----
-RemoteServer server = new RemoteServer("localhost", 5432, "root", "playwithdata");
+RemoteServer server = new RemoteServer("localhost", 2480, "root", "playwithdata");
 ----
 
 Next, let's create a RemoteDatabase instance pointing to the database "mydb" on ArcadeDB Server located on "localhost", port 5432. User and passwords are respectively "root" and "playwithdata":
 
 [source,java]
 ----
-RemoteDatabase database = new RemoteDatabase("localhost", 5432, "mydb", "root", "playwithdata");
+RemoteDatabase database = new RemoteDatabase("localhost", 2480, "mydb", "root", "playwithdata");
 ----
 
 NOTE: The `RemoteDatabase` is not thread-safe. It holds a backend session. If a thread closes a transaction, it also closes the session, so that any request performed by a concurrent thread using the same RemoteDatabase instance leads to unexpected behavior. To avoid concurrency problems you should not hold RemoteDatabase instances as fields on the heap, but rather create a new instance in method scope as a variable on the stack.

--- a/src/main/asciidoc/api/java-ref-database-factory.adoc
+++ b/src/main/asciidoc/api/java-ref-database-factory.adoc
@@ -29,7 +29,7 @@ DatabaseFactory factory = new DatabaseFactory("/databases/mydb");
 ====== close()
 
 Close a database factory.
-This method frees some resources, but it's not necessary to call it to unlock te databases.
+This method frees some resources, but it's not necessary to call it to unlock the databases.
 
 Syntax:
 

--- a/src/main/asciidoc/api/java-tutorial.adoc
+++ b/src/main/asciidoc/api/java-tutorial.adoc
@@ -12,7 +12,7 @@ The entry point it's the `<<DatabaseFactory,DatabaseFactory>>` class that allows
 
 [source,java]
 ----
-DatabaseFactory arcade = new DatabaseFactory("/databases/mydb");
+DatabaseFactory databaseFactory = new DatabaseFactory("/databases/mydb");
 ----
 
 Pass the path in the file system where you want the database to be stored.

--- a/src/main/asciidoc/appendix/community.adoc
+++ b/src/main/asciidoc/appendix/community.adoc
@@ -31,3 +31,7 @@ Join our growing community around the world, for ideas, discussions and help reg
 
 * How are duplicate keys handled in map properties or inserted content?
 ** As in the https://262.ecma-international.org/#sec-json.parse[ECMAScript Specification] (Note 2), duplicate keys in JSON objects are resolved by keeping the last one read and discarding previous ones.
+
+* How can strictly ascending unique identifiers be data modeled with ArcadeDB?
+** One can use a unique index together with transactions of `next_id = max(id) + 1`.
+   See https://www.cybertec-postgresql.com/en/postgresql-sequences-vs-invoice-numbers/ for more details.

--- a/src/main/asciidoc/appendix/managing-dates.adoc
+++ b/src/main/asciidoc/appendix/managing-dates.adoc
@@ -67,7 +67,7 @@ These functions and methods provide you with more control to manage dates:
 | <<_precision,`.precision()`>> | Method modifies the precision of a datetime property. For example, `.precision('millisecond')` returns the datetime property with millisecond precision
 |===
 
-For example, consider a case where you need to extract only the years for date entries and to arrange them in order.  You can use the <<_format,`.format()`>> method to extract dates into different formats.
+For example, consider a case where you need to extract only the years for date entries and to arrange them in order.  You can use the <<_format-method,`.format`>> method to extract dates into different formats.
 
 ```sql
 arcadedb> SELECT @RID, id, date.format('yyyy') AS year FROM Order

--- a/src/main/asciidoc/sql/SQL-Introduction.adoc
+++ b/src/main/asciidoc/sql/SQL-Introduction.adoc
@@ -257,6 +257,17 @@ In ArcadeDB, you can accomplish this with a few variable definitions and by usin
 SELECT expand( $c ) LET $a = ( SELECT FROM E ), $b = ( SELECT FROM V ), $c = unionall( $a, $b )
 ----
 
+*`DISTINCT` vs `distinct()`*
+
+Query results without duplicates can be realized either using the keyword <<SQL-Select,`DISTINCT`>> or the function <<_distinct,`distinct()`>>.
+The keyword `DISTINCT` is be used if the entire projection should be unique,
+while the `distinct` function returns unique elements only for its argument field.
+
+*`UNWIND` vs `expand()`*
+
+Collections fields can be spread into a set of results by either using the keyword <<SQL-Select,`UNWIND`>> or the function <<_expand,`expand()`>>.
+Both produce similar results but via different semantics and constraints.
+
 *SQL Differences*
 
 Following are some basic differences between ArcadeDB and PostgreSQL.

--- a/src/main/asciidoc/sql/SQL-Select.adoc
+++ b/src/main/asciidoc/sql/SQL-Select.adoc
@@ -12,7 +12,8 @@ implementation and the SQL-92 standard, please refer to <<SQL-Introduction,this>
 
 [source,sql]
 ----
-SELECT [ <Projections> ] [ FROM <Target> [ LET <Assignment>* ] ]
+SELECT [ [DISTINCT] <Projections> ]
+    [ FROM <Target> [ LET <Assignment>* ] ]
     [ WHERE <Condition>* ]
     [ GROUP BY <Field>* ]
     [ ORDER BY <Fields>* [ ASC|DESC ] * ]
@@ -26,6 +27,7 @@ SELECT [ <Projections> ] [ FROM <Target> [ LET <Assignment>* ] ]
 * *<<SQL-Projections,`Projections`>>* Indicates the data you want to extract from the query as the result-set. Note: In
  ArcadeDB, this variable is optional. In the projections you can define aliases for single fields, using the `AS` keyword; in
  current release aliases cannot be used in the WHERE condition, GROUP BY and ORDER BY (they will be evaluated to null)
+** `DISTINCT` enforces unique proejction results.
 * *`FROM`* Designates the object to query. This can be a type, bucket, single <<RID,RID>>, set of <<RID,RID>> index values sorted
  by ascending or descending key order.
 ** When querying a type, for `&lt;target&gt;` use the type name.


### PR DESCRIPTION
* Use consistent names in Java tutorial (Section 7.2)
* Use default port in Java tutorial (Section 7.3)
* Fix typo in Java reference (Section 7.4)
* Add discussion about special SQL functions (Section 8)
* Add DISTINCT to SELECT reference entry (Section 8.2)
* Fix link (Section 11.3)
* Add entry about consecutive identifiers to FAQ (11.10)