### PR TITLE
Various Updates

### DIFF
--- a/src/main/asciidoc/api/java-vectors.adoc
+++ b/src/main/asciidoc/api/java-vectors.adoc
@@ -4,7 +4,7 @@ image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/
 
 Using the Embedded Java API is the fastest way to insert vector embeddings into the database. At the beginning it's much faster to pass through the `HnswVectorIndexRAM` implementation and then generate the persistent index after loaded.
 
-Schema types are created automatically, but you could create them in advance if you want special settings, like a specific numbe rof buckets, or a custom page size.
+Schema types are created automatically, but you could create them in advance if you want special settings, like a specific number of buckets, or a custom page size.
 
 Example of inserting embeddings in RAM first, and then create the persistent HNSW index.
 

--- a/src/main/asciidoc/appendix/community.adoc
+++ b/src/main/asciidoc/appendix/community.adoc
@@ -5,6 +5,7 @@ Join our growing community around the world, for ideas, discussions and help reg
 
 - Chat live with us on Discord: https://discord.gg/w2Npx2B7hZ
 - Follow us on Twitter: https://twitter.com/arcade_db
+- or on Bluesky: https://bsky.app/profile/arcadedb.bsky.social
 - Connect with us on LinkedIn: https://www.linkedin.com/products/arcadedb
 - or on Facebook: https://www.facebook.com/arcadedb
 - Questions tagged `#arcadedb` on Stack Overflow: https://stackoverflow.com/questions/tagged/arcadedb

--- a/src/main/asciidoc/appendix/settings.adoc
+++ b/src/main/asciidoc/appendix/settings.adoc
@@ -181,7 +181,7 @@ If you're embedding a server in your Java application you can use these settings
 |`txRetries`|Number of retries in case of MVCC exception|Integer|3
 |`txWAL`|Uses the WAL|Boolean|true
 |`txWalFlush`|Flushes the WAL on disk at commit time. It can be 0 = no flush, 1 = flush without metadata and 2 = full flush (fsync)|Integer|0
-|`typeDefaultBuckets`|Default number of buckets to create per type|Integer|8
+|`typeDefaultBuckets`|Default number of buckets to create per type|Integer|1
 |===
 
 ===== Available Plugins

--- a/src/main/asciidoc/concepts/basics.adoc
+++ b/src/main/asciidoc/concepts/basics.adoc
@@ -127,7 +127,8 @@ Also, <<Inheritance,sub-types>> have their separate buckets from their super-typ
 
 When you create a new type, the <<SQL-Create-Type,`CREATE TYPE`>> statement automatically creates the physical buckets (files) that serve as the default location in which to store data for that type.
 ArcadeDB forms the bucket names by using the type name + underscore + a sequential number starting from 0. For example, the first bucket for the type `Beer` will be `Beer_0` and the correspondent file in the file system will be `Beer_0.31.65536.bucket`.
-ArcadeDB creates additional buckets for each type, (one for each CPU core on the server), to improve performance of parallelism.
+By default ArcadeDB creates one bucket per type. 
+For massive inserts, performance can be improved by creating additional buckets and hence taking advantage of parallelism, i.e. by creating one bucket for each CPU core on the server.
 
 [discrete]
 ==== Types vs. Buckets in Queries

--- a/src/main/asciidoc/sql/SQL-Drop-Type.adoc
+++ b/src/main/asciidoc/sql/SQL-Drop-Type.adoc
@@ -6,6 +6,7 @@
 image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Drop-Type.adoc" float=right]
 
 Removes a type from the schema.
+To drop a type (safely), first, all its instances need to be removed. 
 
 *Syntax*
 

--- a/src/main/asciidoc/sql/SQL-Introduction.adoc
+++ b/src/main/asciidoc/sql/SQL-Introduction.adoc
@@ -18,8 +18,8 @@ For example, if you have a type `MyType` with a field named `id`, then the follo
 
 [source,sql]
 ----
-SELECT FROM MyType WHERE id = 1
-select from MyType where id = 1
+SELECT * FROM MyType WHERE id = 1
+select * from MyType where id = 1
 
 ----
 
@@ -27,7 +27,7 @@ The following is NOT equivalent. Notice that the field name 'ID' is not the same
 
 [source,sql]
 ----
-SELECT FROM MyType WHERE ID = 1
+SELECT * FROM MyType WHERE ID = 1
 
 ----
 
@@ -35,7 +35,7 @@ Also the following query is NOT equivalent because of the type 'mytype ' is not 
 
 [source,sql]
 ----
-SELECT FROM mytype WHERE id = 1
+SELECT * FROM mytype WHERE id = 1
 
 ----
 
@@ -47,7 +47,7 @@ Example:
 
 [source,sql]
 ----
-SELECT FROM INDEX:myIndex WHERE key = 'Jay'
+SELECT * FROM INDEX:myIndex WHERE key = 'Jay'
 ----
 
 *Extra resources*
@@ -182,14 +182,14 @@ projection is optional. Example: In SQL to select all of the columns of Customer
 SELECT * FROM Customer
 ----
 
-In ArcadeDB, the `*` is optional:
+In ArcadeDB, the `*` may be omitted:
 
 [source,sql]
 ----
 SELECT FROM Customer
 ----
 
-See <<SQL-Projections,Projections>>.
+The result is similar, for details see <<_query-results_,Query Results>>.
 
 *System Types*
 

--- a/src/main/asciidoc/sql/SQL-Projections.adoc
+++ b/src/main/asciidoc/sql/SQL-Projections.adoc
@@ -25,7 +25,7 @@ has three projections:
 
 ==== Syntax
 
-*A projection* has the following syntax:
+A *projection* has the following syntax:
 
 `&lt;expression&gt; [&lt;nestedProjection&gt;] [ AS &lt;alias&gt; ]`
 

--- a/src/main/asciidoc/sql/SQL-Projections.adoc
+++ b/src/main/asciidoc/sql/SQL-Projections.adoc
@@ -39,14 +39,13 @@ A projection block has the following syntax:
 * `DISTINCT`: removes duplicates from the result-set
 
 [discrete]
-
 ==== Query result
 
 By default, a query returns a different result-set based on the projections it has:
 
-* `+*+` *alone*: The result set is made of records as they arrive from the target, with the original `@rid` and `@type` attributes (if any)
+* *no projections*: The result set is made of records as they arrive from the target, with the original `@rid` and `@type` attributes (if any)
+* `+*+` *alone*: same behavior as without `+*+` except the `hidden` property attribute is applied.
 * `+*+` *plus other projections*: records of the original target, merged with the other projection values, with `@rid` and `@type` of the original record.
-* *no projections*: same behavior as `*`
 * `expand(&lt;projection&gt;)`: The result set is made of the records returned by the projection, expanded (if the projection result is a link or a collection of links) and unwinded (if the projection result is a collection). Nothing in all the other cases.
 * *one or more projections*: temporary records (with temporary `@rid` and no `@type`). Projections that represent links are returned as simple @rid values, unless differently specified in the fetch plan.
 

--- a/src/main/asciidoc/sql/SQL-Where.adoc
+++ b/src/main/asciidoc/sql/SQL-Where.adoc
@@ -59,7 +59,7 @@ And `item` can be:
 |Apply to|Operator|Description|Example
 |any|`+=+` or `+==+`|Equals|`+name = 'Luke'+`
 |any|`+<=>+`|Null-safe-equals, is also true if left and right operands are `+NULL+`|`+name <=> word+`
-|string|`+LIKE+`|Similar to equals, but allows the wildcards '`+%+`' that means "any characters" and '`+?+`' that means "any single character". `+LIKE+` is case sensitive.|`+name LIKE 'Luk%'+`
+|string|`+LIKE+`|Similar to equals, but allows the wildcards '`+%+`' that means "any characters" and '`+?+`' that means "any single character". `+LIKE+` is case sensitive. Does not index!|`+name LIKE 'Luk%'+`
 |string|`+ILIKE+`|Similar to `+LIKE+`, but `+ILIKE+` is case insensitive.|`+name ILIKE 'lUk%'+`
 |any|`+<+`|Less than|`+age < 40+`
 |any|`+<=+`|Less or equal to|`+age <= 40+`

--- a/src/main/asciidoc/tools/console.adoc
+++ b/src/main/asciidoc/tools/console.adoc
@@ -18,6 +18,7 @@ The following command-line arguments are supported by the console:
 
 * `-D` allows to pass <<#Settings,settings>>,
 * `-b` enables batch mode which exits after executing all commands passed via the command-lines.
+* `-fae` fail-at-end if error occurs during batch (normally batch mode breaks execution at an error).
 
 The console supports these direct commands (not evaluated by the query engine):
 


### PR DESCRIPTION
* Make bucket concept section reflect single bucket per type by default (Section 3.2)
* Add `-fae` switch to console description (Section 6.1)
* Improve documentation of projection with * and without (Section 8)
* Add remark on `LIKE` not using index (Section 8.1)
* Add description on safely dropping types in `DROP TYPE` reference entry (Section 8.2)
* Set default number of bucket per type setting to 1 (Section 11.2)
* Add Bluesky link to community links (section 11.10)
* Fixed typos