### PR TITLE
Fix "sysdate" function reference entry

### DIFF
--- a/src/main/asciidoc/appendix/managing-dates.adoc
+++ b/src/main/asciidoc/appendix/managing-dates.adoc
@@ -60,7 +60,7 @@ These functions and methods provide you with more control to manage dates:
 | SQL | Description
 | <<date,`date()`>> | Function converts dates to and from strings and dates, also uses custom formats.
 | <<sysdate,`sysdate()`>> | Function returns the current date.
-| [[format]]<<format,`.format()`>> | Method returns the date in different formats.
+| <<format-method,`.format()`>> | Method returns the date in different formats.
 | <<asdate,`.asDate()`>> | Method converts any type into a date.
 | <<asdatetime,`.asDatetime()`>> | Method converts any type into datetime.
 | <<aslong,`.asLong()`>> | Method converts any date into long format, (that is, Unix time).

--- a/src/main/asciidoc/sql/sql-functions.adoc
+++ b/src/main/asciidoc/sql/sql-functions.adoc
@@ -1193,9 +1193,9 @@ SELECT * FROM State WHERE strcmpci('washington', name) = 0
 [[sum]]
 ===== sum()
 
-Syntax: `sum(&lt;field&gt;)`
-
 Returns the sum of all the values returned.
+
+Syntax: `sum(&lt;field&gt;)`
 
 *Examples*
 
@@ -1210,10 +1210,10 @@ SELECT sum(salary) FROM Account
 [[symmetricdifference]]
 ===== symmetricDifference()
 
-Syntax: `symmetricDifference(&lt;field&gt; [,&lt;field-n&gt;]*)`
-
 Works as aggregate or inline.
 If only one argument is passed then it aggregates, otherwise executes and returns the SYMMETRIC DIFFERENCE between the collections received as parameters.
+
+Syntax: `symmetricDifference(&lt;field&gt; [,&lt;field-n&gt;]*)`
 
 *Examples*
 
@@ -1233,19 +1233,19 @@ SELECT symmetricDifference(inEdges, outEdges) FROM GraphVertex
 [[sysdate]]
 ===== sysdate()
 
-Returns the current date time.
-If executed with no parameters, it returns a Date object, otherwise a string with the requested format/timezone.
-To know more about it, look at <<managing-dates,Managing Dates>>.
+Returns the current date/time as `DateTime` object.
+To format this object use the <<format-method,`format` method>>.
+For more about dates and times, look at <<managing-dates,Managing Dates>>.
 
 NOTE: The default output format is controlled by the setting <<settings-sql,`arcadedb.dateFormat`>>.
 
-Syntax: `sysdate( [&lt;format&gt;] [,&lt;timezone&gt;] )`
+Syntax: `sysdate()`
 
 *Examples*
 
 [source,sql]
 ----
-SELECT sysdate('dd-MM-yyyy') FROM Account
+SELECT sysdate()
 ----
 
 '''


### PR DESCRIPTION
* Fix sysdate function ref entry (Section 8.3)
* Make function ref entries more consistent (Section 8.3)
* Fix link to format method (Section 11.3)

See https://github.com/ArcadeData/arcadedb/issues/1958