### PR TITLE
Overall fixes

### DIFF
--- a/src/main/asciidoc/api-reference/java/chapter.adoc
+++ b/src/main/asciidoc/api-reference/java/chapter.adoc
@@ -3,8 +3,6 @@
 
 include::java-api.adoc[]
 
-include::../../developer-guide/java-tutorial.adoc[]
-
 include::java-api-remote.adoc[]
 
 include::java-embeddeddoc.adoc[]

--- a/src/main/asciidoc/query-languages/sql/sql-select.adoc
+++ b/src/main/asciidoc/query-languages/sql/sql-select.adoc
@@ -43,7 +43,7 @@ SELECT [ [DISTINCT] <Projections> ]
 *** `INDEXVALUES:&lt;index&gt;` and `INDEXVALUESASC:&lt;index&gt;` sorts values into an ascending order of index keys.
 *** `INDEXVALUESDESC:&lt;index&gt;` sorts the values into a descending order of index keys.
 * *<<filtering,`WHERE`>>* Designates conditions to filter the result-set.
-* *[[sql-let]]<<sql-let,`LET`>>* Binds context variables to use in projections, conditions or sub-queries.
+* *<<sql-let,`LET`>>* Binds context variables to use in projections, conditions or sub-queries.
 * *`GROUP BY`* Designates field on which to group the result-set.
 * *`ORDER BY`* Designates the field with which to order the result-set. Use the optional `ASC` and `DESC` operators to define the
  direction of the order. The default is ascending. Additionally, if you are using a <<sql-projections,projection>>, you
@@ -215,7 +215,7 @@ ArcadeDB> SELECT $path, $depth FROM ( TRAVERSE * FROM Movie WHERE $depth <= 5 )
 ----
 
 [discrete]
-[[let]]
+[[sql-let]]
 ==== `LET` Block
 
 The `LET` block contains context variables to assign each time ArcadeDB evaluates a record. It destroys these values once the query

--- a/src/main/asciidoc/query-languages/sql/sql-where.adoc
+++ b/src/main/asciidoc/query-languages/sql/sql-where.adoc
@@ -130,7 +130,7 @@ ArcadeDB supports variables managed in the context of the command/query. By defa
 |`+$history+`|The set of all the records traversed as a `+Set<RID>+`|<<sql-traverse,TRAVERSE>>
 |===
 
-To set custom variable use the <<let,LET>> keyword.
+To set custom variable use the <<sql-script,LET>> keyword.
 
 [discrete]
 

--- a/src/main/asciidoc/query-languages/sql/sql-where.adoc
+++ b/src/main/asciidoc/query-languages/sql/sql-where.adoc
@@ -130,7 +130,7 @@ ArcadeDB supports variables managed in the context of the command/query. By defa
 |`+$history+`|The set of all the records traversed as a `+Set<RID>+`|<<sql-traverse,TRAVERSE>>
 |===
 
-To set custom variable use the [[sql-let]]<<sql-let,LET>> keyword.
+To set custom variable use the <<let,LET>> keyword.
 
 [discrete]
 


### PR DESCRIPTION
* Remove duplicate section "10 Minute Tutorial (Embedded)" (Section 10.4 is also 7.4)
* Fix ambiguous reference to different SQL `LET`s (Section 8)
* Remove leftover empty file