### PR TITLE
Add ALIASES to ALTER TYPE

### DIFF
--- a/src/main/asciidoc/query-languages/sql/sql-alter-type.adoc
+++ b/src/main/asciidoc/query-languages/sql/sql-alter-type.adoc
@@ -22,6 +22,7 @@ For a list of supported attributes, see the table below.
 * *`&lt;custom-key&gt;`* Name of the custom property to set.
 * *`&lt;custom-value&gt;`* Value for the custom property. All data types are supported as values.
 
+
 NOTE: A custom property can be deleted by setting its value to `null`.
 
 *Examples*
@@ -76,6 +77,12 @@ ArcadeDB> ALTER TYPE Account CUSTOM meta = { abool: true, alist: [1,2,3,4,5]};
 ArcadeDB> ALTER TYPE Account NAME Client;
 ----
 
+* Add the former type name 'Account' as alias for 'Client':
+
+----
+ArcadeDB> ALTER TYPE Client ALIASES Account;
+----
+
 For more information, see:
 
 * <<sql-create-type,`CREATE TYPE`>>
@@ -83,14 +90,15 @@ For more information, see:
 
 *Supported Attributes*
 
-[%header,cols="20%,20%,20%,40%",stripes=even]
+[%header,cols="20%,20%,60%",stripes=even]
 |===
-| Attribute | Type | Support| Description
-| `NAME` | Identifier | | Changes the type name.
-| `SUPERTYPE` | Identifier | |Defines a super-type for the type. Use `NULL` to remove a super-type assignment. It supports multiple
+| Attribute | Type | Description
+| `NAME` | Identifier | Changes the type name.
+| `ALIASES` | Identifier(s) | Add one or more (comma-separated) alternate name(s) for the type name.
+| `SUPERTYPE` | Identifier | Defines a super-type for the type. Use `NULL` to remove a super-type assignment. It supports multiple
 inheritances. To set or add a new type, you can use the syntax `+&lt;type&gt;`, to remove it use `-&lt;type&gt;`.
-| `BUCKET` | Identifier or Integer | | `+` to add a bucket
+| `BUCKET` | Identifier or Integer | `+` to add a bucket
 and `-` to remove it from the type. If the bucket doesn't exist, it creates a physical bucket. Adding buckets to a type is also
 useful in storing records in distributed servers.
-| `BUCKETSELECTIONSTRATEGY` | Identifier | | Change the selection of the bucket when new records are created. Using `partitioned()` is reccomended when your have a unique id
+| `BUCKETSELECTIONSTRATEGY` | Identifier | Change the selection of the bucket when new records are created. Using `partitioned()` is reccomended when your have a unique id
 |===


### PR DESCRIPTION
* Add `ALIASES` attribute to `ALTER TYPE` SQL command with example (Section 8.2)
* Remove unused `Support` column form attribute table under ALTER TYPE (Section 8.2)