### PR TITLE
Add embedded Python bindings to API reference documentation

### DIFF
--- a/src/main/asciidoc/api-reference/chapter.adoc
+++ b/src/main/asciidoc/api-reference/chapter.adoc
@@ -15,6 +15,7 @@ You can use any programming language that supports HTTP calls (pretty much any l
 | Python | https://github.com/adaros92/arcadedb-python-driver | Apache 2
 | Python | https://github.com/ExtReMLapin/pyarcade | Apache 2
 | Python | https://github.com/stevereiner/arcadedb-python | Apache 2
+| Python (embedded) | https://github.com/humemai/arcadedb-embedded-python | Apache 2
 | Ruby | https://github.com/topofocus/arcadedb | MIT
 | RUST | https://crates.io/crates/arcadedb-rs | Apache 2
 | Typescript | https://sprite.tragedy.dev/ | MIT

--- a/src/main/asciidoc/api-reference/python.adoc
+++ b/src/main/asciidoc/api-reference/python.adoc
@@ -2,7 +2,5 @@
 === Python
 image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/api-reference/python.adoc" float=right]
 
-// Besides the Python <<api-reference,drivers>> there are direct bindings for Python available.
-// For details see https://github.com/arcadedata/arcadedb/blob/embedded-python/bindings/python/README.md .
-
-Work in progress
+Besides the Python <<api-reference,drivers>>, ArcadeDB now supports embedded Python bindings.
+See https://github.com/humemai/arcadedb-embedded-python for details.


### PR DESCRIPTION
Embedded python bindings work well.