### PR TITLE
fix: update EXPORT DATABASE syntax to use WITH clause

### DIFF
--- a/src/main/asciidoc/reference/sql/sql-export-database.adoc
+++ b/src/main/asciidoc/reference/sql/sql-export-database.adoc
@@ -9,29 +9,46 @@ Exports a database in the `exports` directory under the root directory where Arc
 
 [source,sql]
 ----
-EXPORT DATABASE [<url>] [FORMAT JSONL|GRAPHML|GRAPHSON] [OVERWRITE TRUE|FALSE]
+EXPORT DATABASE [<url>] [WITH ( <setting-name> = <setting-value> [,] )* ]
 
 ----
 
-* *`&lt;url&gt;`* Defines the location of the file to export. Use:
+* *`&lt;url&gt;`* Optional, defines the location of the file to export. Use:
  ** `file://` as prefix for files located on the same file system where ArcadeDB is running. For security reasons, it is not possible to provide an absolute or relative path to the file
  ** By default the file name is set to `exports/<db-name>-export-<timestamp>.<format>.tgz`.
-* *`&lt;FORMAT&gt;`* The format of the export as a quoted string
- ** *JSONL* exports in https://jsonlines.org/[JSONL] format - a newline-delimited JSON variant (this is the default format)
- ** *GraphML* exports in the popular http://graphml.graphdrawing.org/[GraphML] format. GraphML is supported by all the major Graph DBMS. This format does not support complex types, like collection of elements. Using GraphSON instead of GraphML is recommended
- ** *GraphSON* database export. https://tinkerpop.apache.org/docs/current/dev/io/#graphson[GraphSON] is supported by all the major Graph DBMS
-* *`&lt;OVERWRITE&gt;`* Overwrite the export file if exists. Default is false.
+* *`WITH`* Optional settings as comma-separated key/value pairs:
+ ** *`format`* The format of the export. Default is `jsonl`.
+  *** *`jsonl`* exports in https://jsonlines.org/[JSONL] format - a newline-delimited JSON variant
+  *** *`graphml`* exports in the popular http://graphml.graphdrawing.org/[GraphML] format. GraphML is supported by all the major Graph DBMS. This format does not support complex types, like collection of elements. Using `graphson` instead of `graphml` is recommended
+  *** *`graphson`* exports in the https://tinkerpop.apache.org/docs/current/dev/io/#graphson[GraphSON] format supported by all the major Graph DBMS
+ ** *`overwrite`* Set to `true` to overwrite the export file if it already exists. Default is `false`.
 
 *Examples*
 
-* Export the current database under the `exports/` directory:
+* Export the current database under the `exports/` directory with the default format and filename:
 
+[source,sql]
 ----
-ArcadeDB> EXPORT DATABASE file://database.jsonl.tgz
+EXPORT DATABASE
 ----
 
-* Export the current database in GraphSON format, overwriting any existent file if present:
+* Export the current database to a specific file:
 
+[source,sql]
 ----
-ArcadeDB> EXPORT DATABASE file://Movies.graphson.tgz FORMAT GraphSON OVERWRITE true
+EXPORT DATABASE file://database.jsonl.tgz
+----
+
+* Export the current database in GraphSON format, overwriting any existing file:
+
+[source,sql]
+----
+EXPORT DATABASE file://Movies.graphson.tgz WITH format = 'graphson', overwrite = true
+----
+
+* Export overwriting a previously exported file without specifying a URL:
+
+[source,sql]
+----
+EXPORT DATABASE WITH overwrite = true
 ----


### PR DESCRIPTION
## Summary

- URL is now documented as optional (`EXPORT DATABASE` with no arguments is valid)
- Replace standalone `FORMAT x OVERWRITE y` keyword syntax with `WITH key = value` clause (matching the actual ANTLR grammar and `IMPORT DATABASE` docs style)
- Add example showing `EXPORT DATABASE WITH overwrite = true` without a URL

## References

- ArcadeData/arcadedb#3738
- Discussion: https://github.com/ArcadeData/arcadedb/discussions/3719

🤖 Generated with [Claude Code](https://claude.com/claude-code)