### PR TITLE
docs(k8s): refactor Kubernetes guide around the official Helm chart

### DIFF
--- a/docs/superpowers/plans/2026-05-07-kubernetes-helm-refactor.md
+++ b/docs/superpowers/plans/2026-05-07-kubernetes-helm-refactor.md
@@ -1,0 +1,1078 @@
+# Kubernetes Helm-First Refactor — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rewrite `src/main/asciidoc/how-to/operations/kubernetes.adoc` as a Helm-first guide built around the official `arcadedb-helm` chart, drop the legacy raw-manifest install path, consolidate the K8s/HA content from `ha.adoc` into the new page, and verify both the single-page Asciidoctor build and the Antora build succeed.
+
+**Architecture:** A single `kubernetes.adoc` file is rewritten in place with eight subsections (prereqs, quickstart-on-kind, production install, comprehensive values reference, operate, HA-on-K8s, troubleshooting, reference deployment). The K8s subsection in `ha.adoc` collapses to a one-line cross-reference. No new `.adoc` files are created. Validation runs `docs-validator.py` (cross-refs + naming), `mvn generate-resources` (single-page HTML), and `bash scripts/migrate.sh && npm run build` (Antora).
+
+**Tech Stack:** AsciiDoc (Asciidoctor 2.5.1 + asciidoctorj-pdf 2.3.23), Antora, Maven 3, Python 3 (validator). Chart pinned to `arcadedb-helm` **v26.4.2**.
+
+**Spec:** `docs/superpowers/specs/2026-05-07-kubernetes-helm-refactor-design.md`
+
+---
+
+## File Map
+
+| File | Change | Responsibility |
+|------|--------|----------------|
+| `src/main/asciidoc/how-to/operations/kubernetes.adoc` | Full rewrite | The Kubernetes how-to page (Helm-first) |
+| `src/main/asciidoc/how-to/operations/ha.adoc` | Edit lines ~341–360 | Replace `===== Kubernetes` body with cross-ref to `<<kubernetes-ha,...>>` |
+
+No other files are touched. `chapter.adoc` already includes `kubernetes.adoc` and needs no change.
+
+## Authoritative Sources
+
+These are the references the implementer should keep open while writing the values reference. The plan calls them out instead of inlining their full content because they're the canonical source:
+
+- Chart README: https://github.com/ArcadeData/arcadedb-helm/blob/main/charts/arcadedb/README.md
+- Chart values: https://github.com/ArcadeData/arcadedb-helm/blob/main/charts/arcadedb/values.yaml
+- Reference deployment: https://github.com/ArcadeData/arcadedb-deployments/tree/main/kubernetes
+  - **Important:** Its `values.yaml` wraps everything under top-level `arcadedb:` because it consumes the chart as a *subchart*. When installing the chart **directly** (`helm install my-arcadedb arcadedb/arcadedb`) — which is what we document — values are at the top level (no `arcadedb:` wrapper). Don't copy the deployments-repo file verbatim.
+
+## Convention Reminders
+
+- All file names: lowercase-with-hyphens. (Validator-enforced.)
+- All anchors: lowercase-with-hyphens. Format: `[[anchor-id]]` on its own line directly above a heading.
+- Cross-refs: `<<anchor-id,display text>>`.
+- Code blocks: `[source,shell]`, `[source,yaml]`, `[source,properties]` etc.
+- Tables: `[%header,cols=...]` with `|===` fences. Match the style of the existing `ha.adoc` settings table (lines 392–463).
+- House style: American English spelling, uppercase SQL keywords (not relevant for this page, but stay consistent if any SQL appears).
+
+---
+
+## Task 1: Skeleton — anchors and headings only
+
+**Goal:** Replace the existing 90-line page with the new skeleton (intro paragraph + every section heading and anchor) so subsequent tasks fill in content. After this task, the page builds cleanly with mostly empty sections.
+
+**Files:**
+- Modify (full rewrite): `src/main/asciidoc/how-to/operations/kubernetes.adoc`
+
+- [ ] **Step 1: Confirm chart version**
+
+The plan pins to chart `26.4.2`. If significant time has passed since the spec was written (>30 days), confirm by fetching `https://raw.githubusercontent.com/ArcadeData/arcadedb-helm/main/charts/arcadedb/Chart.yaml` and reading the `version:` field. If newer, use the new version everywhere this plan says `26.4.2`.
+
+- [ ] **Step 2: Rewrite the file with the skeleton**
+
+Replace the entire contents of `src/main/asciidoc/how-to/operations/kubernetes.adoc` with:
+
+```asciidoc
+[[kubernetes]]
+==== Kubernetes
+
+ArcadeDB officially supports deployment on Kubernetes via the https://github.com/ArcadeData/arcadedb-helm[arcadedb-helm] chart, published at `https://helm.arcadedb.com/`.
+The chart deploys ArcadeDB as a `StatefulSet` and, when `replicaCount` is greater than 1, automatically configures a Raft-based <<ha,High Availability>> cluster.
+The reference for the configuration values below targets chart version *26.4.2*; confirm against your installation with `helm show values arcadedb/arcadedb`.
+
+[[kubernetes-prerequisites]]
+===== Prerequisites
+
+[[kubernetes-quickstart]]
+===== Quickstart with kind
+
+[[kubernetes-install]]
+===== Installing the chart
+
+[[kubernetes-values]]
+===== Configuration reference
+
+[[kubernetes-values-image]]
+====== Image
+
+[[kubernetes-values-replicas]]
+====== Replicas
+
+[[kubernetes-values-credentials]]
+====== Credentials
+
+[[kubernetes-values-database]]
+====== Database
+
+[[kubernetes-values-plugins]]
+====== Plugins
+
+[[kubernetes-values-service]]
+====== Service
+
+[[kubernetes-values-ingress]]
+====== Ingress
+
+[[kubernetes-values-persistence]]
+====== Persistence
+
+[[kubernetes-values-resources]]
+====== Resources
+
+[[kubernetes-values-probes]]
+====== Probes
+
+[[kubernetes-values-autoscaling]]
+====== Autoscaling
+
+[[kubernetes-values-security]]
+====== Security context
+
+[[kubernetes-values-serviceaccount]]
+====== Service account
+
+[[kubernetes-values-scheduling]]
+====== Scheduling
+
+[[kubernetes-values-podmetadata]]
+====== Pod metadata
+
+[[kubernetes-values-networkpolicy]]
+====== Network policy
+
+[[kubernetes-values-extras]]
+====== Extras
+
+[[kubernetes-operate]]
+===== Operating the cluster
+
+[[kubernetes-ha]]
+===== High Availability on Kubernetes
+
+[[kubernetes-troubleshooting]]
+===== Troubleshooting
+
+[[kubernetes-reference-deployment]]
+===== Reference deployment
+```
+
+- [ ] **Step 3: Verify the AsciiDoc compiles**
+
+Run: `mvn -q generate-resources -DskipTests 2>&1 | tail -30`
+
+Expected: build succeeds. The single-page HTML at `target/generated-docs/index.html` contains the new section headings (you can grep: `grep -c 'kubernetes-quickstart' target/generated-docs/index.html` should return ≥1).
+
+- [ ] **Step 4: Verify the docs validator passes on naming/structure**
+
+Run: `python docs-validator.py`
+
+Expected: validator passes (or, if it reports unrelated pre-existing failures, none of them mention `kubernetes.adoc` or any of the new `kubernetes-*` anchors).
+
+- [ ] **Step 5: Commit**
+
+```shell
+git add src/main/asciidoc/how-to/operations/kubernetes.adoc
+git commit -m "docs(k8s): scaffold Helm-first kubernetes.adoc skeleton
+
+Replace the legacy raw-manifest page with the section/anchor skeleton
+for the Helm-first rewrite. Subsequent commits fill in each section.
+
+Refs: docs/superpowers/specs/2026-05-07-kubernetes-helm-refactor-design.md"
+```
+
+---
+
+## Task 2: Prerequisites + Quickstart
+
+**Goal:** Fill in the two introductory sections that get a reader from "I have a laptop" to "I have a running cluster I can curl."
+
+**Files:**
+- Modify: `src/main/asciidoc/how-to/operations/kubernetes.adoc`
+
+- [ ] **Step 1: Fill in Prerequisites**
+
+Replace the empty `[[kubernetes-prerequisites]]\n===== Prerequisites\n` section with:
+
+```asciidoc
+[[kubernetes-prerequisites]]
+===== Prerequisites
+
+* Kubernetes 1.19 or later
+* Helm 3.0 or later
+* `kubectl` configured for your target cluster
+* (Optional) `kind` and Docker for the local quickstart below
+```
+
+- [ ] **Step 2: Fill in Quickstart with kind**
+
+Replace the empty `[[kubernetes-quickstart]]\n===== Quickstart with kind\n` section with:
+
+````asciidoc
+[[kubernetes-quickstart]]
+===== Quickstart with kind
+
+This walkthrough mirrors https://github.com/ArcadeData/arcadedb-deployments/tree/main/kubernetes[`ArcadeData/arcadedb-deployments/kubernetes`] and produces a 3-node ArcadeDB cluster on a local https://kind.sigs.k8s.io/[kind] cluster in roughly five minutes.
+
+. Create a local Kubernetes cluster:
++
+[source,shell]
+----
+kind create cluster --name arcadedb
+----
+
+. Create the secret holding the `root` user password (replace `<password>`):
++
+[source,shell]
+----
+kubectl create secret generic arcadedb-credentials \
+  --from-literal=rootPassword='<password>'
+----
+
+. Add the ArcadeDB Helm repository and update:
++
+[source,shell]
+----
+helm repo add arcadedb https://helm.arcadedb.com/
+helm repo update
+----
+
+. Save the following overrides to `values.yaml`:
++
+[source,yaml]
+----
+replicaCount: 3
+image:
+  tag: "26.4.2"
+service:
+  http:
+    type: ClusterIP
+credentials:
+  rootPassword:
+    secret:
+      name: arcadedb-credentials
+      key: rootPassword
+----
+
+. Install the chart:
++
+[source,shell]
+----
+helm install my-arcadedb arcadedb/arcadedb -f values.yaml --wait
+----
+
+. Forward the HTTP port to your laptop:
++
+[source,shell]
+----
+kubectl port-forward svc/my-arcadedb-http 2480:2480
+----
+
+. Open http://localhost:2480 in a browser to reach Studio, or use `curl`:
++
+[source,shell]
+----
+curl -u root:<password> http://localhost:2480/api/v1/server
+----
+
+For a scripted version (with `start.sh`, `stop.sh`, and `test.sh`), see the <<kubernetes-reference-deployment,reference deployment>>.
+````
+
+- [ ] **Step 3: Verify the build still succeeds**
+
+Run: `mvn -q generate-resources -DskipTests 2>&1 | tail -20`
+
+Expected: success.
+
+- [ ] **Step 4: Commit**
+
+```shell
+git add src/main/asciidoc/how-to/operations/kubernetes.adoc
+git commit -m "docs(k8s): add prerequisites and kind quickstart"
+```
+
+---
+
+## Task 3: Production install section
+
+**Goal:** Document the production-oriented install path (no kind), with verification steps and a forward link to the values reference.
+
+**Files:**
+- Modify: `src/main/asciidoc/how-to/operations/kubernetes.adoc`
+
+- [ ] **Step 1: Fill in Installing the chart**
+
+Replace the empty `[[kubernetes-install]]\n===== Installing the chart\n` section with:
+
+````asciidoc
+[[kubernetes-install]]
+===== Installing the chart
+
+For production deployments, follow the same broad shape as the <<kubernetes-quickstart,quickstart>> but tailor `values.yaml` to your environment.
+
+. Add the Helm repository:
++
+[source,shell]
+----
+helm repo add arcadedb https://helm.arcadedb.com/
+helm repo update
+----
+
+. Create a `Secret` containing the `root` password.
+The chart references this secret by name -- it does not store the password in the chart values:
++
+[source,shell]
+----
+kubectl create secret generic arcadedb-credentials \
+  --from-literal=rootPassword='<password>'
+----
+
+. Prepare a `values.yaml` override file that fits your environment.
+At a minimum, set `replicaCount`, `image.tag`, and the `credentials.rootPassword.secret` block.
+See the <<kubernetes-values,configuration reference>> for the full set of options including persistence, ingress, resources, autoscaling, and security context.
+
+. Install the chart:
++
+[source,shell]
+----
+helm install my-arcadedb arcadedb/arcadedb \
+  --namespace arcadedb --create-namespace \
+  --values values.yaml \
+  --wait
+----
+
+. Verify the deployment:
++
+[source,shell]
+----
+kubectl -n arcadedb get statefulset
+kubectl -n arcadedb get pods
+kubectl -n arcadedb get svc
+----
+
+The pods are named `my-arcadedb-0`, `my-arcadedb-1`, ... and reach the `Ready` state once the readiness probe succeeds.
+````
+
+- [ ] **Step 2: Verify the build**
+
+Run: `mvn -q generate-resources -DskipTests 2>&1 | tail -20`
+
+Expected: success.
+
+- [ ] **Step 3: Commit**
+
+```shell
+git add src/main/asciidoc/how-to/operations/kubernetes.adoc
+git commit -m "docs(k8s): add production install walkthrough"
+```
+
+---
+
+## Task 4: Configuration reference — intro and values-table pattern
+
+**Goal:** Add the `===== Configuration reference` intro paragraph (the "what this section is, what version it pins, where to find the source of truth") and write the **first** values group (Image) **fully**, in the exact pattern the rest of the groups will follow. Tasks 5–9 then apply the same pattern to the remaining groups.
+
+**Files:**
+- Modify: `src/main/asciidoc/how-to/operations/kubernetes.adoc`
+
+**Pattern reminder (apply to every values group from this task onward):**
+
+```
+[[kubernetes-values-<group>]]
+====== <Group title>
+
+<One paragraph of prose explaining what the group covers and any cross-cutting
+caveats — e.g. for Resources, "do not set a CPU limit; it interacts badly
+with the JVM GC.">
+
+[%header,cols="2,1,4"]
+|===
+|Key | Default | Description
+
+|`<key>` | `<default>` | <description>
+| ... | ... | ...
+|===
+
+Example override:
+
+[source,yaml]
+----
+<minimal yaml snippet showing typical use of one or two keys from the table>
+----
+```
+
+The `cols="2,1,4"` ratio gives the key column enough room for fully-qualified
+paths and the description column enough room for a sentence. Use this same
+ratio for every group.
+
+- [ ] **Step 1: Fill in the Configuration reference intro**
+
+Replace the empty `[[kubernetes-values]]\n===== Configuration reference\n` line so the heading is followed by:
+
+```asciidoc
+[[kubernetes-values]]
+===== Configuration reference
+
+The values exposed by the chart are grouped below.
+This reference targets chart version *26.4.2*; confirm the current set against your installation with:
+
+[source,shell]
+----
+helm show values arcadedb/arcadedb
+----
+
+The complete and authoritative source is the chart's https://github.com/ArcadeData/arcadedb-helm/blob/main/charts/arcadedb/values.yaml[`values.yaml`].
+The example snippets below show keys at the top level (the chart is installed directly as `arcadedb/arcadedb`); if you consume the chart as a *subchart* under a parent named `arcadedb`, wrap each snippet under a top-level `arcadedb:` key.
+```
+
+- [ ] **Step 2: Fill in the Image group (full pattern)**
+
+Replace the empty `[[kubernetes-values-image]]\n====== Image\n` section with:
+
+````asciidoc
+[[kubernetes-values-image]]
+====== Image
+
+Selects the container image, pull policy, and pull secrets.
+Override `image.tag` to pin to a specific ArcadeDB release; otherwise the chart's `appVersion` is used.
+
+[%header,cols="2,1,4"]
+|===
+|Key | Default | Description
+
+|`image.registry` | `arcadedata` | Container registry hosting the image
+|`image.repository` | `arcadedb` | Image repository name
+|`image.tag` | (chart `appVersion`) | Image tag; pin to a specific ArcadeDB version for reproducible deployments
+|`image.pullPolicy` | `IfNotPresent` | Kubernetes image pull policy
+|`imagePullSecrets` | `[]` | List of `Secret` references for private registries
+|`nameOverride` | `""` | Overrides the chart name used in resource names
+|`fullnameOverride` | `""` | Overrides the fully-qualified app name used in resource names
+|===
+
+Example override:
+
+[source,yaml]
+----
+image:
+  tag: "26.4.2"
+  pullPolicy: IfNotPresent
+imagePullSecrets:
+  - name: my-registry-secret
+----
+````
+
+- [ ] **Step 3: Verify the build**
+
+Run: `mvn -q generate-resources -DskipTests 2>&1 | tail -20`
+
+Expected: success. Spot-check the table renders correctly: `grep -c 'image.registry' target/generated-docs/index.html` returns at least 1.
+
+- [ ] **Step 4: Commit**
+
+```shell
+git add src/main/asciidoc/how-to/operations/kubernetes.adoc
+git commit -m "docs(k8s): add values reference intro and Image group"
+```
+
+---
+
+## Task 5: Values reference — Replicas, Credentials, Database, Plugins
+
+**Goal:** Apply the pattern from Task 4 to four more groups. Source content from the chart's `values.yaml` and `README.md` (linked in *Authoritative Sources* at the top of this plan). Use the same `[%header,cols="2,1,4"]` table format and trailing example snippet.
+
+**Files:**
+- Modify: `src/main/asciidoc/how-to/operations/kubernetes.adoc`
+
+- [ ] **Step 1: Fill in Replicas**
+
+Replace the empty section. Cover at minimum:
+
+* `replicaCount` — number of pods. Default `1`. Values > 1 enable Raft HA automatically. Cross-reference: `<<kubernetes-ha,High Availability on Kubernetes>>` for the implications.
+
+The example snippet should show `replicaCount: 3` and a one-line note that 3 is the smallest cluster that tolerates one node failure under majority quorum.
+
+- [ ] **Step 2: Fill in Credentials**
+
+Cover:
+
+* `credentials.rootPassword.secret.name` — name of the `Secret` containing the password
+* `credentials.rootPassword.secret.key` — key within the `Secret`
+
+Defaults: per the chart's `values.yaml` (typically empty/required). Include a one-paragraph caution that the password must be set before installation; missing-secret pods crash-loop, mentioned again in <<kubernetes-troubleshooting>>.
+
+Example snippet: the same secret-creation `kubectl create secret` shown in the quickstart, followed by the matching `values.yaml` block.
+
+- [ ] **Step 3: Fill in Database**
+
+Cover:
+
+* `arcadedb.databaseDirectory` — path inside the container (default `/home/arcadedb/databases`)
+* `arcadedb.defaultDatabases` — databases to create at startup
+* `arcadedb.extraCommands` — additional JVM arguments (default `["-Darcadedb.server.mode=production"]`)
+* `arcadedb.extraEnvironment` — extra environment variables passed to the container
+
+Example snippet: a minimal `extraCommands` override adding a custom JVM flag, plus an `extraEnvironment` map setting one env var.
+
+- [ ] **Step 4: Fill in Plugins**
+
+Cover the wire-protocol plugin toggles. Per the chart's `values.yaml`, this is `arcadedb.plugins.<name>.enabled` for: `gremlin`, `postgres`, `mongo`, `redis`, `prometheus`, plus a `custom` slot for user plugins.
+
+Example snippet: enabling the Postgres and Mongo wire protocols.
+
+- [ ] **Step 5: Verify the build**
+
+Run: `mvn -q generate-resources -DskipTests 2>&1 | tail -20`
+
+Expected: success.
+
+- [ ] **Step 6: Commit**
+
+```shell
+git add src/main/asciidoc/how-to/operations/kubernetes.adoc
+git commit -m "docs(k8s): add Replicas, Credentials, Database, Plugins values"
+```
+
+---
+
+## Task 6: Values reference — Service, Ingress, Persistence
+
+**Goal:** Three more values groups, same pattern.
+
+**Files:**
+- Modify: `src/main/asciidoc/how-to/operations/kubernetes.adoc`
+
+- [ ] **Step 1: Fill in Service**
+
+Cover:
+
+* `service.http.type` — Service type (default `ClusterIP`; common alternatives `NodePort`, `LoadBalancer`)
+* `service.http.port` — HTTP port (default `2480`)
+* `service.rpc.port` — Raft gRPC port (default `2434`)
+
+Note the difference between the public HTTP service and the internal Raft RPC port (the headless service used by Raft is created automatically by the chart and is not directly exposed to users — call this out).
+
+Example snippet: switching the HTTP service to `LoadBalancer`.
+
+- [ ] **Step 2: Fill in Ingress**
+
+Cover:
+
+* `ingress.enabled` (default `false`)
+* `ingress.className`
+* `ingress.annotations`
+* `ingress.hosts` (list of `host` + `paths`)
+* `ingress.tls`
+
+Example snippet: a single-host ingress with TLS and a `cert-manager` annotation.
+
+- [ ] **Step 3: Fill in Persistence**
+
+Cover:
+
+* `persistence.enabled` (default `true` — recommend keeping it on)
+* `persistence.size` (default `8Gi`)
+* `persistence.accessMode` (default `ReadWriteOnce`)
+* `persistence.storageClass` (default `""` → cluster default)
+
+Add a sidebar note that PVCs created by the StatefulSet **survive `helm uninstall`** by design. To delete them, run:
+
+```shell
+kubectl delete pvc -l app.kubernetes.io/name=arcadedb -n <namespace>
+```
+
+This same `kubectl delete pvc` line will be referenced again in `<<kubernetes-operate>>` and `<<kubernetes-troubleshooting>>`.
+
+Example snippet: enabling persistence with a 50Gi PVC on a named storage class.
+
+- [ ] **Step 4: Verify the build**
+
+Run: `mvn -q generate-resources -DskipTests 2>&1 | tail -20`
+
+Expected: success.
+
+- [ ] **Step 5: Commit**
+
+```shell
+git add src/main/asciidoc/how-to/operations/kubernetes.adoc
+git commit -m "docs(k8s): add Service, Ingress, Persistence values"
+```
+
+---
+
+## Task 7: Values reference — Resources, Probes, Autoscaling
+
+**Goal:** Three more groups. Two of them carry important caveats — make sure the prose includes them.
+
+**Files:**
+- Modify: `src/main/asciidoc/how-to/operations/kubernetes.adoc`
+
+- [ ] **Step 1: Fill in Resources**
+
+Cover:
+
+* `resources.requests.cpu`, `resources.requests.memory`
+* `resources.limits.memory`
+* (intentionally **no** CPU limit by default)
+
+Include the warning from the chart README:
+
+> Avoid setting a CPU limit. CPU throttling interacts poorly with the JVM garbage collector and can cause GC pauses much larger than the throttling window. Use a CPU *request* to size scheduling and memory limits to bound the working set.
+
+Example snippet:
+
+```yaml
+resources:
+  requests:
+    cpu: 500m
+    memory: 2Gi
+  limits:
+    memory: 4Gi
+```
+
+- [ ] **Step 2: Fill in Probes**
+
+Cover `livenessProbe` and `readinessProbe` — both are full Kubernetes probe objects in the chart. List the typical sub-keys (`httpGet.path`, `httpGet.port`, `initialDelaySeconds`, `periodSeconds`, `timeoutSeconds`, `failureThreshold`). Defaults: refer to the chart's `values.yaml`.
+
+Example snippet: bumping `initialDelaySeconds` for slow-start environments.
+
+- [ ] **Step 3: Fill in Autoscaling**
+
+Cover:
+
+* `autoscaling.enabled` (default `false`)
+* `autoscaling.minReplicas`
+* `autoscaling.maxReplicas`
+* `autoscaling.targetCPUUtilizationPercentage`
+
+Include the Raft caveat as a callout:
+
+> When autoscaling is enabled in an HA configuration, ensure `minReplicas >= floor(maxReplicas / 2) + 1` so the cluster always has a Raft majority. Falling below the quorum threshold causes writes to stall.
+
+Example snippet: enabling autoscaling with `minReplicas: 3, maxReplicas: 5`.
+
+- [ ] **Step 4: Verify the build**
+
+Run: `mvn -q generate-resources -DskipTests 2>&1 | tail -20`
+
+Expected: success.
+
+- [ ] **Step 5: Commit**
+
+```shell
+git add src/main/asciidoc/how-to/operations/kubernetes.adoc
+git commit -m "docs(k8s): add Resources, Probes, Autoscaling values"
+```
+
+---
+
+## Task 8: Values reference — Security, Service account, Scheduling, Pod metadata, Network policy, Extras
+
+**Goal:** Final six values groups. Pattern is the same; these are mostly straightforward Kubernetes plumbing.
+
+**Files:**
+- Modify: `src/main/asciidoc/how-to/operations/kubernetes.adoc`
+
+- [ ] **Step 1: Fill in Security context**
+
+Cover both pod-level and container-level keys:
+
+* `podSecurityContext.runAsNonRoot` (default `true`)
+* `podSecurityContext.fsGroup` (default `1000`)
+* `securityContext.runAsUser` (default `1000`)
+* `securityContext.allowPrivilegeEscalation` (default `false`)
+* (any others present in the chart values — check `values.yaml`)
+
+One sentence noting the container runs as non-root by default.
+
+Example snippet: tightening `securityContext` further (e.g. `readOnlyRootFilesystem: true` if the chart supports it).
+
+- [ ] **Step 2: Fill in Service account**
+
+Cover:
+
+* `serviceAccount.create` (default `true`)
+* `serviceAccount.automount`
+* `serviceAccount.annotations`
+* `serviceAccount.name`
+
+Example snippet: re-using an existing service account (e.g. for IRSA on EKS).
+
+- [ ] **Step 3: Fill in Scheduling**
+
+Cover `nodeSelector`, `tolerations`, `affinity`. Defaults are empty. Mention pod anti-affinity as the typical use case (spread Raft peers across nodes).
+
+Example snippet: a pod anti-affinity rule that prefers different nodes for each replica.
+
+- [ ] **Step 4: Fill in Pod metadata**
+
+Cover `podAnnotations` and `podLabels`. One sentence each.
+
+Example snippet: a Prometheus scrape annotation pair.
+
+- [ ] **Step 5: Fill in Network policy**
+
+Cover `networkPolicy.enabled` (and any nested keys present in the chart's `values.yaml`). Defaults: per chart. One sentence on what enabling it does (creates a `NetworkPolicy` allowing only the documented ports).
+
+Example snippet: enabling network policy.
+
+- [ ] **Step 6: Fill in Extras**
+
+Cover `extraManifests`, `volumes`, `volumeMounts`, `volumeClaimTemplates`. These are escape hatches. One sentence each.
+
+Example snippet: mounting an extra `ConfigMap` as a config file.
+
+- [ ] **Step 7: Verify the build**
+
+Run: `mvn -q generate-resources -DskipTests 2>&1 | tail -20`
+
+Expected: success.
+
+- [ ] **Step 8: Commit**
+
+```shell
+git add src/main/asciidoc/how-to/operations/kubernetes.adoc
+git commit -m "docs(k8s): add remaining values reference groups"
+```
+
+---
+
+## Task 9: Operating the cluster
+
+**Goal:** Document scaling, upgrading, and uninstalling. Emphasize the `helm upgrade` vs `kubectl scale` distinction.
+
+**Files:**
+- Modify: `src/main/asciidoc/how-to/operations/kubernetes.adoc`
+
+- [ ] **Step 1: Fill in Operating the cluster**
+
+Replace the empty `[[kubernetes-operate]]\n===== Operating the cluster\n` section with:
+
+````asciidoc
+[[kubernetes-operate]]
+===== Operating the cluster
+
+====== Scaling
+
+Use `helm upgrade` to change the replica count persistently:
+
+[source,shell]
+----
+helm upgrade my-arcadedb arcadedb/arcadedb \
+  --namespace arcadedb \
+  --reuse-values \
+  --set replicaCount=5
+----
+
+`kubectl scale statefulset` also works for an immediate, one-off change:
+
+[source,shell]
+----
+kubectl -n arcadedb scale statefulset my-arcadedb --replicas=5
+----
+
+A `kubectl scale` change is reverted on the next `helm upgrade` because Helm reapplies the `replicaCount` from the chart values.
+For persistent changes, prefer `helm upgrade --set replicaCount=N` (or update the values file).
+
+Scaling does not pause the workload.
+New pods auto-join the Raft cluster, and pods removed during scale-down auto-leave via the `preStop` hook (see <<kubernetes-ha,High Availability on Kubernetes>>).
+
+====== Upgrading the chart
+
+[source,shell]
+----
+helm repo update
+helm upgrade my-arcadedb arcadedb/arcadedb \
+  --namespace arcadedb \
+  --reuse-values
+----
+
+Pin `image.tag` to a specific ArcadeDB version for reproducible upgrades.
+
+====== Uninstalling
+
+[source,shell]
+----
+helm uninstall my-arcadedb --namespace arcadedb
+----
+
+Persistent volume claims **survive uninstall** by design.
+To remove them too:
+
+[source,shell]
+----
+kubectl -n arcadedb delete pvc -l app.kubernetes.io/name=arcadedb
+----
+
+The `Secret` holding the root password is not managed by Helm and is also retained.
+Delete it explicitly if no longer needed.
+````
+
+- [ ] **Step 2: Verify the build**
+
+Run: `mvn -q generate-resources -DskipTests 2>&1 | tail -20`
+
+Expected: success.
+
+- [ ] **Step 3: Commit**
+
+```shell
+git add src/main/asciidoc/how-to/operations/kubernetes.adoc
+git commit -m "docs(k8s): add operate-the-cluster section"
+```
+
+---
+
+## Task 10: High Availability on Kubernetes
+
+**Goal:** Move the K8s/HA content from `ha.adoc:341–360` into this page (slightly expanded), and on a successful build edit `ha.adoc` to cross-reference here.
+
+**Files:**
+- Modify: `src/main/asciidoc/how-to/operations/kubernetes.adoc`
+- Modify: `src/main/asciidoc/how-to/operations/ha.adoc:341-360`
+
+- [ ] **Step 1: Fill in High Availability on Kubernetes (in kubernetes.adoc)**
+
+Replace the empty `[[kubernetes-ha]]\n===== High Availability on Kubernetes\n` section with:
+
+````asciidoc
+[[kubernetes-ha]]
+===== High Availability on Kubernetes
+
+ArcadeDB on Kubernetes uses the standard `StatefulSet` + headless `Service` pattern (the same pattern used by `etcd`, CockroachDB, and Apache Ozone).
+The chart pre-computes the full peer list from `replicaCount` and injects it into each pod via environment variables, so users do not configure `arcadedb.ha.serverList` by hand.
+
+The chart sets the equivalent of:
+
+[source,properties]
+----
+arcadedb.ha.enabled=true
+arcadedb.ha.k8s=true
+arcadedb.ha.k8sSuffix=.my-arcadedb.arcadedb.svc.cluster.local
+arcadedb.ha.serverList=my-arcadedb-0.my-arcadedb.arcadedb.svc.cluster.local:2434:2480,my-arcadedb-1.my-arcadedb.arcadedb.svc.cluster.local:2434:2480,my-arcadedb-2.my-arcadedb.arcadedb.svc.cluster.local:2434:2480
+----
+
+(Substitute your release name and namespace.)
+
+*Auto-join on scale-up* (since `26.4.1`)::
+When `arcadedb.ha.k8s=true` and a new pod starts without an existing Raft storage directory, the server automatically joins the existing cluster via the Raft `SetConfiguration(ADD)` admin API.
+This enables zero-downtime scale-up: `helm upgrade --set replicaCount=N` (or `kubectl scale statefulset`) adds new pods that join the existing cluster without restarting any existing peer.
+
+*Auto-leave on scale-down*::
+The chart installs a `preStop` hook that calls `POST /api/v1/cluster/leave` so the terminating pod cleanly transfers leadership (if it holds it) and removes itself from the Raft group before shutdown.
+
+For the rest of the Raft semantics -- quorum, named peers, snapshot threshold, election timeouts, cluster token, replication failure handling -- see <<ha,High Availability>>.
+````
+
+- [ ] **Step 2: Verify the build still succeeds**
+
+Run: `mvn -q generate-resources -DskipTests 2>&1 | tail -20`
+
+Expected: success.
+
+- [ ] **Step 3: Replace the K8s subsection in ha.adoc**
+
+In `src/main/asciidoc/how-to/operations/ha.adoc`, locate the section starting at the heading `===== Kubernetes` (around line 341) and ending at the line above `===== Troubleshooting` (around line 361). Replace the entire body of `===== Kubernetes` (everything from the heading through the last bullet about auto-leave) with:
+
+```asciidoc
+===== Kubernetes
+
+For Kubernetes deployments using the official Helm chart -- including the `StatefulSet` + headless `Service` pattern, auto-join on scale-up, and the `preStop` auto-leave hook -- see <<kubernetes-ha,High Availability on Kubernetes>> in the Kubernetes guide.
+```
+
+(Use `Edit` with the exact `old_string` matching the existing `===== Kubernetes` heading and its body. Do not modify `===== Troubleshooting` or anything below it.)
+
+- [ ] **Step 4: Verify the cross-reference resolves**
+
+Run: `python docs-validator.py`
+
+Expected: validator passes (no broken cross-references). The new `<<kubernetes-ha,...>>` link from `ha.adoc` resolves to the anchor created in step 1.
+
+Run: `mvn -q generate-resources -DskipTests 2>&1 | tail -20`
+
+Expected: success. Spot-check: `grep -c 'kubernetes-ha' target/generated-docs/index.html` returns at least 2 (the anchor itself + the cross-ref from ha.adoc).
+
+- [ ] **Step 5: Commit**
+
+```shell
+git add src/main/asciidoc/how-to/operations/kubernetes.adoc src/main/asciidoc/how-to/operations/ha.adoc
+git commit -m "docs(k8s,ha): consolidate K8s/HA content into kubernetes.adoc
+
+Move the StatefulSet + headless service + auto-join/auto-leave content
+out of ha.adoc into the new kubernetes-ha section, and replace the
+ha.adoc subsection with a one-line cross-reference."
+```
+
+---
+
+## Task 11: Troubleshooting + Reference deployment
+
+**Goal:** Final two sections.
+
+**Files:**
+- Modify: `src/main/asciidoc/how-to/operations/kubernetes.adoc`
+
+- [ ] **Step 1: Fill in Troubleshooting**
+
+Replace the empty `[[kubernetes-troubleshooting]]\n===== Troubleshooting\n` section with:
+
+````asciidoc
+[[kubernetes-troubleshooting]]
+===== Troubleshooting
+
+The most common deployment failure is a missing or incorrectly named `rootPassword` `Secret` -- pods crash-loop with an authentication-related error in the log.
+Verify the secret exists and that the chart's `credentials.rootPassword.secret.name` and `.key` match it.
+
+Inspect a pod's events:
+
+[source,shell]
+----
+kubectl -n arcadedb describe pod my-arcadedb-0
+----
+
+Read the server log:
+
+[source,shell]
+----
+kubectl -n arcadedb logs my-arcadedb-0
+----
+
+(Replace `my-arcadedb-0` with the pod name you want to inspect.)
+
+To tear down a stuck cluster and start over:
+
+[source,shell]
+----
+helm uninstall my-arcadedb --namespace arcadedb
+kubectl -n arcadedb delete pvc -l app.kubernetes.io/name=arcadedb
+----
+
+Then re-run `helm install` with corrected values.
+````
+
+- [ ] **Step 2: Fill in Reference deployment**
+
+Replace the empty `[[kubernetes-reference-deployment]]\n===== Reference deployment\n` section with:
+
+````asciidoc
+[[kubernetes-reference-deployment]]
+===== Reference deployment
+
+The https://github.com/ArcadeData/arcadedb-deployments[`ArcadeData/arcadedb-deployments`] repository hosts a working, scripted reference deployment under https://github.com/ArcadeData/arcadedb-deployments/tree/main/kubernetes[`kubernetes/`].
+It pairs a https://kind.sigs.k8s.io/[kind] cluster with the official chart and provides:
+
+* `start.sh` -- creates the kind cluster, runs `helm dependency update` + `helm install --wait`, and starts a port-forward to `localhost:2480`.
+* `stop.sh` -- terminates the port-forward, runs `helm uninstall`, and destroys the kind cluster.
+* `test.sh` -- validates that the cluster is functional.
+* `values.yaml` -- the values overrides used by `start.sh`. Note that this file wraps overrides under a top-level `arcadedb:` key because it consumes the chart as a *subchart*; when installing the chart directly (the path documented above), use the same overrides at the top level.
+
+Use this repository as a starting point for your own setup and as a reproducible bug-report environment.
+````
+
+- [ ] **Step 3: Verify the build**
+
+Run: `mvn -q generate-resources -DskipTests 2>&1 | tail -20`
+
+Expected: success.
+
+- [ ] **Step 4: Commit**
+
+```shell
+git add src/main/asciidoc/how-to/operations/kubernetes.adoc
+git commit -m "docs(k8s): add troubleshooting and reference deployment sections"
+```
+
+---
+
+## Task 12: Final validation pass
+
+**Goal:** Run every validation and rendering command in the spec to confirm the rewrite is shippable. Fix anything that breaks.
+
+**Files:**
+- Read-only verification, plus possible spot fixes if anything fails.
+
+- [ ] **Step 1: Run the docs validator**
+
+Run: `python docs-validator.py`
+
+Expected: passes. If it reports broken cross-references involving the new `kubernetes-*` anchors or any existing `<<kubernetes,...>>` callers, fix the offending anchor or reference inline.
+
+- [ ] **Step 2: Confirm no anchor collisions**
+
+Run:
+
+```shell
+for a in kubernetes-prerequisites kubernetes-quickstart kubernetes-install kubernetes-values kubernetes-operate kubernetes-ha kubernetes-troubleshooting kubernetes-reference-deployment kubernetes-values-image kubernetes-values-replicas kubernetes-values-credentials kubernetes-values-database kubernetes-values-plugins kubernetes-values-service kubernetes-values-ingress kubernetes-values-persistence kubernetes-values-resources kubernetes-values-probes kubernetes-values-autoscaling kubernetes-values-security kubernetes-values-serviceaccount kubernetes-values-scheduling kubernetes-values-podmetadata kubernetes-values-networkpolicy kubernetes-values-extras; do
+  count=$(grep -r "\[\[$a\]\]" src/main/asciidoc/ | wc -l)
+  echo "$a: $count"
+done
+```
+
+Expected: every anchor reports `1`. Any value other than 1 indicates a duplicate or missing definition; fix and rerun.
+
+- [ ] **Step 3: Build the single-page HTML**
+
+Run: `mvn generate-resources`
+
+Expected: build succeeds, no Asciidoctor warnings or errors. The output file `target/generated-docs/index.html` exists.
+
+- [ ] **Step 4: Build the PDF**
+
+Run: `mvn -Pgenerate-pdf generate-resources`
+
+Expected: success. `target/generated-docs/ArcadeDB-Manual.pdf` exists.
+
+- [ ] **Step 5: Build the Antora site**
+
+Run:
+
+```shell
+npm ci
+bash scripts/migrate.sh
+npm run build
+```
+
+Expected: success. `build/site/` exists and contains a Kubernetes page derived from `kubernetes.adoc` (find it with `find build/site -name 'kubernetes*' -type f`).
+
+- [ ] **Step 6: Spot-check the rendered output**
+
+Open `target/generated-docs/index.html` in a browser (or inspect with `grep`/`less`) and verify:
+
+* The intro paragraph appears with the correct chart-version pin (`26.4.2`).
+* All eight subsections render in order.
+* The values reference tables render correctly (header row, three columns).
+* The cross-reference from `ha.adoc` resolves: search for `High Availability on Kubernetes` in the rendered HA chapter and confirm it links to the Kubernetes section.
+
+Locate the same page in `build/site/` (Antora output) and repeat the spot-check.
+
+- [ ] **Step 7: If everything passes, no commit needed**
+
+If steps 1–6 pass without changes, the work from previous tasks is complete and committed. If you made fixes during this task, commit them:
+
+```shell
+git add -A
+git commit -m "docs(k8s): post-validation fixes"
+```
+
+- [ ] **Step 8: Summarize**
+
+Report:
+* Total commits added on this branch
+* Each validation command's pass/fail status
+* Any deviations from the spec (there should be none; if so, document why)
+
+---
+
+## Self-Review
+
+**Spec coverage check:**
+
+| Spec section | Implementing task(s) |
+|--------------|----------------------|
+| Page outline → intro | Task 1 (skeleton) |
+| Page outline → Prerequisites | Task 2 |
+| Page outline → Quickstart with kind | Task 2 |
+| Page outline → Installing the chart | Task 3 |
+| Page outline → Configuration reference (intro + 16 groups) | Tasks 4, 5, 6, 7, 8 |
+| Page outline → Operating the cluster | Task 9 |
+| Page outline → High Availability on Kubernetes | Task 10 |
+| Page outline → Troubleshooting | Task 11 |
+| Page outline → Reference deployment | Task 11 |
+| Cross-references → ha.adoc edit | Task 10 |
+| Cross-references → new sub-anchors | Task 1 (skeleton creates them) |
+| Maintenance → chart version pin | Task 1 (intro), Task 4 (values intro) |
+| Maintenance → source-of-truth pointer | Task 4 (values intro) |
+| Validation → docs-validator.py | Tasks 1, 10, 12 |
+| Validation → mvn generate-resources | every task |
+| Validation → mvn -Pgenerate-pdf | Task 12 |
+| Validation → migrate.sh + npm run build | Task 12 |
+| Validation → manual read-through | Task 12 step 6 |
+| Validation → anchor uniqueness | Task 12 step 2 |
+
+No gaps.
+
+**Placeholder scan:** No "TBD", "TODO", or vague "add appropriate X" instructions. Every step shows the exact AsciiDoc to write or the exact command to run, with one deliberate, structured exception: Tasks 5–8 specify the *content* of each values group ("cover these keys, with this defaults, with this caveat, with this example pattern") rather than reproducing the full chart `values.yaml` inline. This is intentional — the chart's `values.yaml` is the source of truth and must be opened by the implementer; reproducing it here would re-create the drift problem. Each step still names every key to cover, every default value, every caveat callout, and the structure of the example snippet.
+
+**Type consistency check:** Anchor names match between definition and reference sites (`kubernetes-ha` defined in Task 1, referenced from `ha.adoc` in Task 10; `kubernetes-troubleshooting` defined in Task 1, referenced from quickstart in Task 2 implicitly via "see troubleshooting"). Service names (`my-arcadedb-http`), pod names (`my-arcadedb-0..N`), and namespace (`arcadedb`) are consistent across quickstart, install, operate, and troubleshooting sections.

--- a/docs/superpowers/specs/2026-05-07-kubernetes-helm-refactor-design.md
+++ b/docs/superpowers/specs/2026-05-07-kubernetes-helm-refactor-design.md
@@ -1,0 +1,289 @@
+# Kubernetes documentation refactor — Helm-first
+
+**Date:** 2026-05-07
+**Author:** robfrank (with Claude Code)
+**Status:** Approved (pending implementation)
+**Affected page:** `src/main/asciidoc/how-to/operations/kubernetes.adoc`
+
+## Goal
+
+Rewrite the Kubernetes how-to page so that the official Helm chart from
+[`ArcadeData/arcadedb-helm`](https://github.com/ArcadeData/arcadedb-helm)
+(published to `https://helm.arcadedb.com/`) is the single, canonical install
+path. Replace the legacy `kubectl apply -f arcadedb-statefulset.yaml` flow
+entirely. Add a comprehensive `values.yaml` reference, a kind-based quickstart
+that mirrors `ArcadeData/arcadedb-deployments`, and consolidate the
+Kubernetes-specific HA content currently in `ha.adoc` into this page.
+
+## Background
+
+`kubernetes.adoc` today (90 lines) leads with raw-manifest installation
+(`kubectl apply -f config/arcadedb-statefulset.yaml`) and treats Helm as a
+short footnote that points to a local chart path (`./arcadedb`). This is out
+of date in three ways:
+
+1. The chart now lives in its own repository (`ArcadeData/arcadedb-helm`) and
+   is published to a public Helm repo (`https://helm.arcadedb.com/`); users
+   should install via `helm repo add` rather than from a checkout.
+2. `ArcadeData/arcadedb-deployments` provides a working, scripted reference
+   deployment (kind cluster + values overrides + start/stop/test scripts)
+   that readers should be able to discover from the manual.
+3. `ha.adoc` already covers `arcadedb.ha.k8s`, `arcadedb.ha.k8sSuffix`,
+   auto-join, and the preStop auto-leave hook in a small `===== Kubernetes`
+   subsection (lines 341–360). With the page being rewritten, this content
+   belongs on the Kubernetes page where readers will look for it; `ha.adoc`
+   should cross-reference instead of duplicating.
+
+## Scope
+
+### In scope
+
+- **Full rewrite** of `src/main/asciidoc/how-to/operations/kubernetes.adoc`
+- **Edit** to `src/main/asciidoc/how-to/operations/ha.adoc`: replace the
+  `===== Kubernetes` subsection (lines ~341–360) with a one-line cross-
+  reference pointing to the new Kubernetes page section.
+- New sub-anchors on the Kubernetes page so other pages (and ha.adoc) can
+  deep-link.
+
+### Out of scope
+
+- Changes to `arcadedb-helm` (the chart itself).
+- Changes to `arcadedb-deployments`.
+- Other AsciiDoc pages that mention Kubernetes incidentally
+  (`concepts/high-availability.adoc:130`, `tutorials/run.adoc`,
+  `concepts/databases.adoc`, etc.) — single-line mentions that remain
+  accurate; leave alone.
+- Modifying `chapter.adoc` — it already includes `kubernetes.adoc`.
+- Documentation of the Docker Compose HA scenario in `arcadedb-deployments`
+  (covered by the existing Docker page).
+
+## Page outline
+
+The new `kubernetes.adoc` is organized linearly, simple → advanced, so
+newcomers can stop after the quickstart and reference readers can jump to
+the relevant section. All anchors are lowercase-with-hyphens per
+`docs-validator.py`.
+
+```
+[[kubernetes]]
+==== Kubernetes
+
+  [Intro: 2–3 sentences. Recommends the official Helm chart from
+   helm.arcadedb.com. Notes that ArcadeDB on Kubernetes runs as a
+   StatefulSet and supports Raft HA when replicaCount > 1.]
+
+[[kubernetes-prerequisites]]
+===== Prerequisites
+  - Kubernetes 1.19+
+  - Helm 3+
+  - kubectl configured for the target cluster
+
+[[kubernetes-quickstart]]
+===== Quickstart with kind
+  Five-minute path mirroring arcadedb-deployments/kubernetes/start.sh:
+  1. kind create cluster
+  2. kubectl create secret generic arcadedb-credentials
+       --from-literal=rootPassword='...'
+  3. helm repo add arcadedb https://helm.arcadedb.com/
+     helm repo update
+  4. helm install my-arcadedb arcadedb/arcadedb
+       --set replicaCount=3
+       --set service.http.type=ClusterIP
+       --wait
+     (or with a values.yaml file — show both)
+  5. kubectl port-forward svc/my-arcadedb-http 2480:2480
+  6. Open http://localhost:2480 (Studio) or curl with root credentials
+  Closing line: "see arcadedb-deployments/kubernetes for the scripted
+  version with start/stop/test."
+
+[[kubernetes-install]]
+===== Installing the chart
+  Production-oriented walkthrough (no kind):
+  - Add the Helm repo and update
+  - Create the rootPassword secret
+  - Prepare a values.yaml override file (link forward to the reference)
+  - helm install with --values
+  - Verify: kubectl get statefulset, get pods, get svc
+  - First connection (root + chosen password)
+
+[[kubernetes-values]]
+===== Configuration reference
+  Brief intro: "These are the values exposed by the official chart. For the
+  complete and current list, see the chart's values.yaml. The reference
+  below targets chart version v<X.Y> — confirm against your installed
+  version with `helm show values arcadedb/arcadedb`."
+
+  Grouped reference (each group: short prose + table key/default/description
+  + a small values.yaml snippet showing typical use):
+
+  - Image: registry, repository, tag, pullPolicy, imagePullSecrets,
+    nameOverride, fullnameOverride
+  - Replicas: replicaCount (with the Raft HA implication, link to
+    kubernetes-ha)
+  - Credentials: arcadedb.credentials.rootPassword.secret.{name,key}
+  - Database: arcadedb.databaseDirectory, defaultDatabases, extraCommands,
+    extraEnvironment
+  - Plugins: arcadedb.plugins.{gremlin, postgres, mongo, redis, prometheus,
+    custom}
+  - Service: service.http.{type,port}, service.rpc.port
+  - Ingress: enabled, className, annotations, hosts, tls
+  - Persistence: enabled, size, accessMode, storageClass + a note about
+    PVCs surviving helm uninstall
+  - Resources: requests + limits, with the "no CPU limit to avoid GC
+    throttling" note from the chart README
+  - Probes: liveness, readiness
+  - Autoscaling: enabled, minReplicas, maxReplicas,
+    targetCPUUtilizationPercentage, with the Raft quorum caveat
+    (minReplicas >= floor(maxReplicas/2)+1)
+  - Security context: pod-level (runAsNonRoot, fsGroup) and container-level
+    (runAsUser, allowPrivilegeEscalation)
+  - Service account: create, automount, annotations, name
+  - Scheduling: nodeSelector, tolerations, affinity
+  - Pod metadata: podAnnotations, podLabels
+  - Network policy: networkPolicy.enabled
+  - Extras: extraManifests, volumes, volumeMounts, volumeClaimTemplates
+
+[[kubernetes-operate]]
+===== Operating the cluster
+  - Scaling:
+    Recommended (persistent): helm upgrade --set replicaCount=N
+    One-off (reverted on next helm upgrade): kubectl scale statefulset
+    Note that scaling does not pause workload (existing point in
+    today's page — preserve).
+  - Upgrading the chart: helm repo update, helm upgrade.
+  - Uninstalling: helm uninstall my-arcadedb. Mention that PVCs persist
+    by default — show kubectl delete pvc when a clean slate is wanted.
+
+[[kubernetes-ha]]
+===== High Availability on Kubernetes
+  Content adapted from ha.adoc:341-360:
+  - StatefulSet + Headless Service pattern (peer of etcd, CockroachDB,
+    Apache Ozone)
+  - The chart pre-computes the full serverList from replicaCount and
+    injects via env vars — users typically do not configure
+    arcadedb.ha.serverList by hand.
+  - Minimal effective configuration (the four properties: ha.enabled,
+    ha.k8s, ha.k8sSuffix, ha.serverList) — show as the chart-rendered
+    result, not as something users edit.
+  - Auto-join on scale-up (v26.4.1+).
+  - Auto-leave on scale-down (preStop hook → POST /api/v1/cluster/leave).
+  - Cross-reference to <<ha,High Availability>> for the rest of Raft
+    semantics (quorum, named peers, snapshot threshold, election
+    timeouts, etc.).
+
+[[kubernetes-troubleshooting]]
+===== Troubleshooting
+  - Root password not set / pod CrashLoopBackOff: the most common cause
+    (preserved from today's page).
+  - kubectl describe pod arcadedb-0 — read events.
+  - kubectl logs arcadedb-0 — read server log.
+  - Tearing down a stuck cluster: helm uninstall + optional kubectl
+    delete pvc -l app.kubernetes.io/name=arcadedb.
+
+[[kubernetes-reference-deployment]]
+===== Reference deployment
+  Link: ArcadeData/arcadedb-deployments — kubernetes/ directory has a
+  scripted kind-based example (start.sh / stop.sh / test.sh, plus a
+  values.yaml override) that pairs well with the quickstart above and
+  serves as a starting point for your own setup.
+```
+
+## Cross-references and external links
+
+### Internal anchors
+
+- `[[kubernetes]]` — preserved (outbound links from `ha.adoc:16`,
+  `chapter.adoc:45 include`, etc., are unchanged)
+- New: `[[kubernetes-prerequisites]]`, `[[kubernetes-quickstart]]`,
+  `[[kubernetes-install]]`, `[[kubernetes-values]]`,
+  `[[kubernetes-operate]]`, `[[kubernetes-ha]]`,
+  `[[kubernetes-troubleshooting]]`, `[[kubernetes-reference-deployment]]`
+- All anchors lowercase-with-hyphens (CLAUDE.md naming convention,
+  enforced by `docs-validator.py`).
+
+### Edit to ha.adoc
+
+Replace lines ~341–360 (`===== Kubernetes` ... auto-leave bullet) with:
+
+```asciidoc
+===== Kubernetes
+
+For Kubernetes deployments using the official Helm chart, including
+auto-join on scale-up and the preStop auto-leave hook, see
+<<kubernetes-ha,High Availability on Kubernetes>>.
+```
+
+### External links (verified during exploration)
+
+- `https://helm.arcadedb.com/` — Helm repository
+- `https://github.com/ArcadeData/arcadedb-helm` — chart source
+- `https://github.com/ArcadeData/arcadedb-deployments` — reference
+  deployments (kubernetes/ directory)
+- `https://github.com/ArcadeData/arcadedb-helm/blob/main/charts/arcadedb/README.md`
+  — chart README (linked from the values reference intro)
+- `https://github.com/ArcadeData/arcadedb-helm/blob/main/charts/arcadedb/values.yaml`
+  — values source-of-truth (linked from the values reference intro)
+
+The legacy link to
+`https://github.com/ArcadeData/arcadedb/blob/main/package/src/main/config/arcadedb-statefulset.yaml`
+is removed — the raw-manifest path is dropped entirely.
+
+The legacy link to
+`https://github.com/ArcadeData/arcadedb/blob/main/k8s/helm/README.md`
+is removed — superseded by the chart's own repo README.
+
+## Maintenance plan
+
+A comprehensive inline values reference can drift from the chart. We accept
+the trade-off (the user explicitly chose comprehensive over brief), and we
+limit drift cost with three measures:
+
+1. **Chart version pin in the page.** The intro to the values reference
+   names the chart version it was written against. Readers can resolve any
+   discrepancy with `helm show values arcadedb/arcadedb`.
+2. **Single source-of-truth pointer.** The same intro links to the chart's
+   `values.yaml` so a reader who needs the absolute current state can find
+   it in one click.
+3. **Sync expectation.** When `arcadedb-helm` cuts a new minor release that
+   adds, removes, or renames values, this page should be reviewed. The
+   design itself documents this expectation; we are not adding tooling for
+   it now.
+
+## Validation
+
+Before merging:
+
+1. `python docs-validator.py` — naming + cross-ref validation passes (no
+   broken `<<...>>` references; all new anchors and files follow
+   lowercase-with-hyphens convention).
+2. `mvn generate-resources` — single-page HTML build succeeds without
+   Asciidoctor errors.
+3. `bash scripts/migrate.sh && npm run build` — Antora build succeeds and
+   the page renders at `build/site/.../kubernetes.html`.
+4. Manual read-through of both rendered outputs to confirm formatting,
+   table layout, code-block syntax highlighting, and that all
+   cross-references resolve.
+5. Confirm anchor uniqueness — no collision with anchors elsewhere in the
+   manual (grep for each new anchor name).
+6. `mvn -Pgenerate-pdf generate-resources` — PDF builds without errors and
+   the new page reads cleanly in PDF.
+
+## Risks and mitigations
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| Values reference drifts from chart | Medium | Chart version pin + source-of-truth link in the page |
+| Existing `<<kubernetes,...>>` links break | Low | Top-level `[[kubernetes]]` anchor preserved |
+| ha.adoc edit breaks an inbound link | Low | grep for `kubernetes-ha` (does not exist today) and `<<kubernetes,` (existing — preserved); the only content moved is the body of `===== Kubernetes`, no anchor was attached to it |
+| Inline kind quickstart drifts from arcadedb-deployments scripts | Low | Quickstart is intentionally minimal; the deployments link is the canonical scripted version |
+| Reader confusion about kubectl scale vs helm upgrade | Medium | Operate section calls out the difference explicitly |
+
+## Open questions
+
+None — all decisions resolved during brainstorming:
+
+- Raw-manifest path: drop entirely
+- Values reference depth: comprehensive inline
+- arcadedb-deployments treatment: inline kind quickstart + see-also link
+- ha.adoc overlap: consolidate K8s/HA content into kubernetes.adoc
+- Page structure: linear tutorial-first (Approach A)

--- a/src/main/asciidoc/how-to/operations/ha.adoc
+++ b/src/main/asciidoc/how-to/operations/ha.adoc
@@ -340,23 +340,7 @@ It is *not* a substitute for mTLS: deploy HA behind a private network, NetworkPo
 
 ===== Kubernetes
 
-ArcadeDB supports the standard StatefulSet + Headless Service pattern for Raft deployments (similar to etcd, Apache Ozone, CockroachDB).
-The official Helm chart pre-computes the full server list from `replicaCount` and injects it via environment variables.
-
-Minimal configuration:
-
-[source,properties]
-----
-arcadedb.ha.enabled=true
-arcadedb.ha.k8s=true
-arcadedb.ha.k8sSuffix=.arcadedb.default.svc.cluster.local
-arcadedb.ha.serverList=arcadedb-0.arcadedb.default.svc.cluster.local:2434:2480,arcadedb-1.arcadedb.default.svc.cluster.local:2434:2480,arcadedb-2.arcadedb.default.svc.cluster.local:2434:2480
-----
-
-*Auto-join on scale-up (from v26.4.1)*:: When `arcadedb.ha.k8s=true` and a new pod starts without an existing Raft storage directory, the server automatically joins the existing cluster via the Raft `SetConfiguration(ADD)` admin API.
-This enables zero-downtime scale-up: `kubectl scale statefulset arcadedb --replicas=5` adds new pods that join the existing cluster without restarting the existing peers.
-
-*Auto-leave on scale-down*:: The Helm chart installs a `preStop` hook that calls `POST /api/v1/cluster/leave` so the terminating pod cleanly transfers leadership (if it holds it) and is removed from the Raft group before shutdown.
+For Kubernetes deployments using the official Helm chart -- including the `StatefulSet` + headless `Service` pattern, auto-join on scale-up, and the `preStop` auto-leave hook -- see <<kubernetes-ha,High Availability on Kubernetes>> in the Kubernetes guide.
 
 ===== Troubleshooting
 

--- a/src/main/asciidoc/how-to/operations/kubernetes.adoc
+++ b/src/main/asciidoc/how-to/operations/kubernetes.adoc
@@ -84,6 +84,50 @@ For a scripted version (with `start.sh`, `stop.sh`, and `test.sh`), see the <<ku
 [[kubernetes-install]]
 ===== Installing the chart
 
+For production deployments, follow the same broad shape as the <<kubernetes-quickstart,quickstart>> but tailor `values.yaml` to your environment.
+
+. Add the Helm repository:
++
+[source,shell]
+----
+helm repo add arcadedb https://helm.arcadedb.com/
+helm repo update
+----
+
+. Create a `Secret` containing the `root` password.
+The chart references this secret by name -- it does not store the password in the chart values:
++
+[source,shell]
+----
+kubectl create secret generic arcadedb-credentials \
+  --from-literal=rootPassword='<password>'
+----
+
+. Prepare a `values.yaml` override file that fits your environment.
+At a minimum, set `replicaCount`, `image.tag`, and the `credentials.rootPassword.secret` block.
+See the <<kubernetes-values,configuration reference>> for the full set of options including persistence, ingress, resources, autoscaling, and security context.
+
+. Install the chart:
++
+[source,shell]
+----
+helm install my-arcadedb arcadedb/arcadedb \
+  --namespace arcadedb --create-namespace \
+  --values values.yaml \
+  --wait
+----
+
+. Verify the deployment:
++
+[source,shell]
+----
+kubectl -n arcadedb get statefulset
+kubectl -n arcadedb get pods
+kubectl -n arcadedb get svc
+----
+
+The pods are named `my-arcadedb-0`, `my-arcadedb-1`, ... and reach the `Ready` state once the readiness probe succeeds.
+
 [[kubernetes-values]]
 ===== Configuration reference
 

--- a/src/main/asciidoc/how-to/operations/kubernetes.adoc
+++ b/src/main/asciidoc/how-to/operations/kubernetes.adoc
@@ -287,11 +287,103 @@ arcadedb:
 [[kubernetes-values-service]]
 ====== Service
 
+The chart creates two Kubernetes `Service` objects for each ArcadeDB deployment.
+The *HTTP service* (named `<release>-http`) exposes port 2480 where Studio and all REST/HTTP clients connect; its type is configurable below.
+The *RPC service* is a headless `ClusterIP` service used only for Raft peer discovery between pods — it is internal-only and not directly controlled by these values.
+
+[%header,cols="2,1,4"]
+|===
+|Key | Default | Description
+
+|`service.http.type` | `ClusterIP` | Kubernetes service type for the HTTP service. Use `LoadBalancer` to obtain an external IP, or leave `ClusterIP` and configure <<kubernetes-values-ingress,Ingress>> for a single-entry-point setup.
+|`service.http.port` | `2480` | Port exposed by the HTTP service. Studio and all REST/HTTP clients connect to this port.
+|`service.rpc.port` | `2434` | Raft gRPC port used for HA peer communication. This port is exposed only on the headless internal service; do not expose it externally.
+|===
+
+Example override:
+
+[source,yaml]
+----
+service:
+  http:
+    type: LoadBalancer
+    port: 2480
+----
+
 [[kubernetes-values-ingress]]
 ====== Ingress
 
+Use an `Ingress` resource when you want a single external entry point with host-based routing and TLS termination at the edge controller, without assigning a cloud load-balancer IP per service.
+For simpler setups or clouds where a managed load-balancer IP is acceptable, `service.http.type: LoadBalancer` is the lower-configuration alternative.
+
+[%header,cols="2,1,4"]
+|===
+|Key | Default | Description
+
+|`ingress.enabled` | `false` | Set to `true` to create an `Ingress` resource for the HTTP service.
+|`ingress.className` | `""` | IngressClass name (e.g. `nginx`, `traefik`). Empty string uses the cluster-default class.
+|`ingress.annotations` | `{}` | Annotations added to the `Ingress` object. Commonly used to configure the ingress controller behavior (e.g. `cert-manager.io/cluster-issuer`).
+|`ingress.hosts` | (see description) | List of host rules. Each entry has a `host` string and a `paths` list (each with `path` and `pathType`). Default example uses host `chart-example.local` with path `/`.
+|`ingress.tls` | `[]` | TLS configuration. Each entry specifies a `secretName` (holding the TLS certificate) and the list of `hosts` it covers.
+|===
+
+Example override (single-host ingress with TLS via cert-manager):
+
+[source,yaml]
+----
+ingress:
+  enabled: true
+  className: nginx
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+  hosts:
+    - host: arcadedb.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: arcadedb-tls
+      hosts:
+        - arcadedb.example.com
+----
+
 [[kubernetes-values-persistence]]
 ====== Persistence
+
+ArcadeDB stores its database files under `arcadedb.databaseDirectory` (default `/home/arcadedb/databases`).
+The chart uses a `volumeClaimTemplates` block in the `StatefulSet`, so Kubernetes provisions one `PersistentVolumeClaim` per pod rather than sharing a single volume across replicas.
+
+[NOTE]
+====
+PVCs created by the StatefulSet survive `helm uninstall` by design — Kubernetes preserves data volumes when a workload is deleted.
+To remove them along with the release, run:
+
+[source,shell]
+----
+kubectl delete pvc -l app.kubernetes.io/name=arcadedb -n <namespace>
+----
+====
+
+[%header,cols="2,1,4"]
+|===
+|Key | Default | Description
+
+|`persistence.enabled` | `true` | Enable PVC-backed storage. Set to `false` only for ephemeral development deployments; all data is lost when the pod restarts.
+|`persistence.size` | `8Gi` | Requested PVC capacity. Size the volume to hold your databases plus headroom for growth.
+|`persistence.accessMode` | `ReadWriteOnce` | PVC access mode. `ReadWriteOnce` is correct for the `StatefulSet` pattern (one pod per volume).
+|`persistence.storageClass` | `""` | StorageClass name. Empty string uses the cluster-default class (e.g. `standard` on GKE, `gp2` on EKS). Set explicitly to select a faster or differently-billed class.
+|`volumeClaimTemplates` | `[]` | Extra `volumeClaimTemplates` for the StatefulSet (config, replication, backups, log). The primary database PVC is controlled by `persistence.enabled` above.
+|===
+
+Example override (50 Gi PVC on the `gp3` storage class on AWS EKS):
+
+[source,yaml]
+----
+persistence:
+  enabled: true
+  size: 50Gi
+  storageClass: gp3
+----
 
 [[kubernetes-values-resources]]
 ====== Resources

--- a/src/main/asciidoc/how-to/operations/kubernetes.adoc
+++ b/src/main/asciidoc/how-to/operations/kubernetes.adoc
@@ -53,16 +53,16 @@ The reference for the configuration values below targets chart version *26.4.2*;
 [[kubernetes-values-security]]
 ====== Security context
 
-[[kubernetes-values-serviceaccount]]
+[[kubernetes-values-service-account]]
 ====== Service account
 
 [[kubernetes-values-scheduling]]
 ====== Scheduling
 
-[[kubernetes-values-podmetadata]]
+[[kubernetes-values-pod-metadata]]
 ====== Pod metadata
 
-[[kubernetes-values-networkpolicy]]
+[[kubernetes-values-network-policy]]
 ====== Network policy
 
 [[kubernetes-values-extras]]

--- a/src/main/asciidoc/how-to/operations/kubernetes.adoc
+++ b/src/main/asciidoc/how-to/operations/kubernetes.adoc
@@ -388,11 +388,125 @@ persistence:
 [[kubernetes-values-resources]]
 ====== Resources
 
+Container resource requests and limits are deliberately left unset in the chart defaults (`resources: {}`), so you must supply them for any production deployment.
+Size the memory request to match your JVM heap (`-Xms`) so the scheduler places the pod on a node with enough RAM, and set a memory limit slightly above the heap to catch unexpected off-heap growth.
+
+[IMPORTANT]
+====
+Do *not* set a CPU limit on ArcadeDB pods.
+Kubernetes CPU throttling operates on a 100 ms accounting window; when a CPU limit is hit mid-GC cycle, the JVM thread is suspended until the next window, turning a millisecond collection into a multi-hundred-millisecond pause.
+Set a CPU *request* so the scheduler reserves the right amount of CPU for scheduling purposes, and rely on node-level CPU sharing — not a hard limit — to bound consumption.
+Memory limits are safe and recommended: the JVM respects its heap ceiling, and a hard memory limit prevents a runaway process from affecting other pods on the node.
+====
+
+[%header,cols="2,1,4"]
+|===
+|Key | Default | Description
+
+|`resources.requests.cpu` | (absent) | CPU request used by the scheduler to place the pod. Recommended starting point: `500m`. No CPU limit should be set — see the note above.
+|`resources.requests.memory` | (absent) | Memory request. Should equal or slightly exceed the JVM `-Xms` value to guarantee the node has enough RAM at scheduling time.
+|`resources.limits.memory` | (absent) | Memory limit. Set to the JVM `-Xmx` value plus headroom for off-heap buffers (e.g. `4Gi` for a 2 Gi heap). Prevents a single pod from consuming all node memory.
+|===
+
+Example override (2 Gi heap, 4 Gi limit, CPU request only — no CPU limit):
+
+[source,yaml]
+----
+resources:
+  requests:
+    cpu: 500m
+    memory: 2Gi
+  limits:
+    memory: 4Gi
+----
+
 [[kubernetes-values-probes]]
 ====== Probes
 
+Kubernetes uses *liveness probes* to decide when to kill and restart a container, and *readiness probes* to decide when a pod is safe to receive traffic.
+Both probes matter for ArcadeDB: on a cold start the JVM and optional persistence rehydration can take several seconds, so tuning `initialDelaySeconds` prevents premature restarts before the server is ready.
+
+The chart configures both probes to poll `GET /api/v1/ready` on the HTTP port (2480).
+Only `httpGet.path` and `httpGet.port` are set by default; all other sub-keys (`initialDelaySeconds`, `periodSeconds`, `timeoutSeconds`, `failureThreshold`, `successThreshold`) are absent and fall back to Kubernetes defaults (0 s delay, 10 s period, 1 s timeout, 3 failures, 1 success).
+
+[%header,cols="2,1,4"]
+|===
+|Key | Default | Description
+
+|`livenessProbe.httpGet.path` | `/api/v1/ready` | HTTP path polled by the liveness probe. Returns 200 when the server is alive.
+|`livenessProbe.httpGet.port` | `http` | Named port (`http`, resolving to 2480) used by the liveness probe.
+|`livenessProbe.initialDelaySeconds` | (absent — Kubernetes default: `0`) | Seconds to wait after container start before the first liveness check. Increase for slow-start environments (cold JVM + persistence rehydration).
+|`livenessProbe.periodSeconds` | (absent — Kubernetes default: `10`) | How often (in seconds) to run the liveness probe.
+|`livenessProbe.timeoutSeconds` | (absent — Kubernetes default: `1`) | Seconds after which a probe attempt times out.
+|`livenessProbe.failureThreshold` | (absent — Kubernetes default: `3`) | Number of consecutive failures before the container is killed and restarted.
+|`livenessProbe.successThreshold` | (absent — Kubernetes default: `1`) | Consecutive successes required to mark the container as live again after a failure.
+|`readinessProbe.httpGet.path` | `/api/v1/ready` | HTTP path polled by the readiness probe. Returns 200 when the server is ready to accept traffic.
+|`readinessProbe.httpGet.port` | `http` | Named port (`http`, resolving to 2480) used by the readiness probe.
+|`readinessProbe.initialDelaySeconds` | (absent — Kubernetes default: `0`) | Seconds to wait after container start before the first readiness check. Increase when the server needs time to rehydrate databases from a PVC before accepting connections.
+|`readinessProbe.periodSeconds` | (absent — Kubernetes default: `10`) | How often (in seconds) to run the readiness probe.
+|`readinessProbe.timeoutSeconds` | (absent — Kubernetes default: `1`) | Seconds after which a probe attempt times out.
+|`readinessProbe.failureThreshold` | (absent — Kubernetes default: `3`) | Number of consecutive failures before the pod is removed from Service endpoints.
+|`readinessProbe.successThreshold` | (absent — Kubernetes default: `1`) | Consecutive successes required to add the pod back to Service endpoints.
+|===
+
+Example override (bumping the initial delay for a slow-start environment with large persisted databases):
+
+[source,yaml]
+----
+livenessProbe:
+  httpGet:
+    path: /api/v1/ready
+    port: http
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 6
+readinessProbe:
+  httpGet:
+    path: /api/v1/ready
+    port: http
+  initialDelaySeconds: 20
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+----
+
 [[kubernetes-values-autoscaling]]
 ====== Autoscaling
+
+The chart supports Kubernetes `HorizontalPodAutoscaler` (HPA) to scale the number of ArcadeDB pods based on CPU utilization.
+Autoscaling is disabled by default; enable it only after verifying that your storage class supports `ReadWriteOnce` volumes on all potential target nodes, and that your HA configuration can tolerate dynamic replica counts.
+
+[IMPORTANT]
+====
+When autoscaling is enabled in an HA configuration, ensure `minReplicas >= floor(maxReplicas / 2) + 1` so the cluster always retains a Raft majority.
+Falling below the quorum threshold causes writes to stall until enough peers rejoin.
+For example, with `maxReplicas: 5` the minimum safe `minReplicas` is `3`.
+See <<kubernetes-ha,High Availability on Kubernetes>> for further guidance on Raft quorum sizing.
+
+The chart also pre-sizes the internal server list to `maxReplicas` for auto-join purposes; set `maxReplicas` conservatively to avoid advertising pod addresses that may never exist.
+====
+
+[%header,cols="2,1,4"]
+|===
+|Key | Default | Description
+
+|`autoscaling.enabled` | `false` | Set to `true` to create an `HorizontalPodAutoscaler` that scales the `StatefulSet` based on CPU utilization.
+|`autoscaling.minReplicas` | `1` | Minimum number of replicas the HPA will scale down to. In an HA cluster this must be at least `floor(maxReplicas / 2) + 1` to preserve Raft quorum.
+|`autoscaling.maxReplicas` | `5` | Maximum number of replicas the HPA will scale up to. Set conservatively — the chart pre-sizes the peer list to this value.
+|`autoscaling.targetCPUUtilizationPercentage` | `80` | Average CPU utilization target (as a percentage of the pod's CPU request) that triggers scale-out. Lower values scale out earlier; higher values pack more load per pod.
+|===
+
+Example override (autoscaling with Raft-safe quorum bounds):
+
+[source,yaml]
+----
+autoscaling:
+  enabled: true
+  minReplicas: 3
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 70
+----
 
 [[kubernetes-values-security]]
 ====== Security context

--- a/src/main/asciidoc/how-to/operations/kubernetes.adoc
+++ b/src/main/asciidoc/how-to/operations/kubernetes.adoc
@@ -51,11 +51,12 @@ image:
 service:
   http:
     type: ClusterIP
-credentials:
-  rootPassword:
-    secret:
-      name: arcadedb-credentials
-      key: rootPassword
+arcadedb:
+  credentials:
+    rootPassword:
+      secret:
+        name: arcadedb-credentials
+        key: rootPassword
 ----
 
 . Install the chart:
@@ -372,7 +373,6 @@ kubectl delete pvc -l app.kubernetes.io/name=arcadedb -n <namespace>
 |`persistence.size` | `8Gi` | Requested PVC capacity. Size the volume to hold your databases plus headroom for growth.
 |`persistence.accessMode` | `ReadWriteOnce` | PVC access mode. `ReadWriteOnce` is correct for the `StatefulSet` pattern (one pod per volume).
 |`persistence.storageClass` | `""` | StorageClass name. Empty string uses the cluster-default class (e.g. `standard` on GKE, `gp2` on EKS). Set explicitly to select a faster or differently-billed class.
-|`volumeClaimTemplates` | `[]` | Extra `volumeClaimTemplates` for the StatefulSet (config, replication, backups, log). The primary database PVC is controlled by `persistence.enabled` above.
 |===
 
 Example override (50 Gi PVC on the `gp3` storage class on AWS EKS):
@@ -653,7 +653,7 @@ Example override (Prometheus scrape annotations):
 podAnnotations:
   prometheus.io/scrape: "true"
   prometheus.io/port: "2480"
-  prometheus.io/path: "/api/v1/server"
+  prometheus.io/path: "/metrics"
 ----
 
 [NOTE]
@@ -809,7 +809,7 @@ The chart sets the equivalent of:
 arcadedb.ha.enabled=true
 arcadedb.ha.k8s=true
 arcadedb.ha.k8sSuffix=.my-arcadedb.arcadedb.svc.cluster.local
-arcadedb.ha.serverList=my-arcadedb-0.my-arcadedb.arcadedb.svc.cluster.local:2434:2480,my-arcadedb-1.my-arcadedb.arcadedb.svc.cluster.local:2434:2480,my-arcadedb-2.my-arcadedb.arcadedb.svc.cluster.local:2434:2480
+arcadedb.ha.serverList=my-arcadedb-0.my-arcadedb.arcadedb.svc.cluster.local:2434,my-arcadedb-1.my-arcadedb.arcadedb.svc.cluster.local:2434,my-arcadedb-2.my-arcadedb.arcadedb.svc.cluster.local:2434
 ----
 
 (Substitute your release name and namespace.)

--- a/src/main/asciidoc/how-to/operations/kubernetes.adoc
+++ b/src/main/asciidoc/how-to/operations/kubernetes.adoc
@@ -8,8 +8,78 @@ The reference for the configuration values below targets chart version *26.4.2*;
 [[kubernetes-prerequisites]]
 ===== Prerequisites
 
+* Kubernetes 1.19 or later
+* Helm 3.0 or later
+* `kubectl` configured for your target cluster
+* (Optional) `kind` and Docker for the local quickstart below
+
 [[kubernetes-quickstart]]
 ===== Quickstart with kind
+
+This walkthrough mirrors https://github.com/ArcadeData/arcadedb-deployments/tree/main/kubernetes[`ArcadeData/arcadedb-deployments/kubernetes`] and produces a 3-node ArcadeDB cluster on a local https://kind.sigs.k8s.io/[kind] cluster in roughly five minutes.
+
+. Create a local Kubernetes cluster:
++
+[source,shell]
+----
+kind create cluster --name arcadedb
+----
+
+. Create the secret holding the `root` user password (replace `<password>`):
++
+[source,shell]
+----
+kubectl create secret generic arcadedb-credentials \
+  --from-literal=rootPassword='<password>'
+----
+
+. Add the ArcadeDB Helm repository and update:
++
+[source,shell]
+----
+helm repo add arcadedb https://helm.arcadedb.com/
+helm repo update
+----
+
+. Save the following overrides to `values.yaml`:
++
+[source,yaml]
+----
+replicaCount: 3
+image:
+  tag: "26.4.2"
+service:
+  http:
+    type: ClusterIP
+credentials:
+  rootPassword:
+    secret:
+      name: arcadedb-credentials
+      key: rootPassword
+----
+
+. Install the chart:
++
+[source,shell]
+----
+helm install my-arcadedb arcadedb/arcadedb -f values.yaml --wait
+----
+
+. Forward the HTTP port to your laptop:
++
+[source,shell]
+----
+kubectl port-forward svc/my-arcadedb-http 2480:2480
+----
+
+. Open http://localhost:2480 in a browser to reach Studio, or use `curl`:
++
+[source,shell]
+----
+curl -u root:<password> http://localhost:2480/api/v1/server
+----
+
+For a scripted version (with `start.sh`, `stop.sh`, and `test.sh`), see the <<kubernetes-reference-deployment,reference deployment>>.
 
 [[kubernetes-install]]
 ===== Installing the chart

--- a/src/main/asciidoc/how-to/operations/kubernetes.adoc
+++ b/src/main/asciidoc/how-to/operations/kubernetes.adoc
@@ -826,5 +826,44 @@ For the rest of the Raft semantics -- quorum, named peers, snapshot threshold, e
 [[kubernetes-troubleshooting]]
 ===== Troubleshooting
 
+The most common deployment failure is a missing or incorrectly named `rootPassword` `Secret` -- pods crash-loop with an authentication-related error in the log.
+Verify the secret exists and that the chart's `credentials.rootPassword.secret.name` and `.key` match it.
+
+Inspect a pod's events:
+
+[source,shell]
+----
+kubectl -n arcadedb describe pod my-arcadedb-0
+----
+
+Read the server log:
+
+[source,shell]
+----
+kubectl -n arcadedb logs my-arcadedb-0
+----
+
+(Replace `my-arcadedb-0` with the pod name you want to inspect.)
+
+To tear down a stuck cluster and start over:
+
+[source,shell]
+----
+helm uninstall my-arcadedb --namespace arcadedb
+kubectl -n arcadedb delete pvc -l app.kubernetes.io/name=arcadedb
+----
+
+Then re-run `helm install` with corrected values.
+
 [[kubernetes-reference-deployment]]
 ===== Reference deployment
+
+The https://github.com/ArcadeData/arcadedb-deployments[`ArcadeData/arcadedb-deployments`] repository hosts a working, scripted reference deployment under https://github.com/ArcadeData/arcadedb-deployments/tree/main/kubernetes[`kubernetes/`].
+It pairs a https://kind.sigs.k8s.io/[kind] cluster with the official chart and provides:
+
+* `start.sh` -- creates the kind cluster, runs `helm dependency update` + `helm install --wait`, and starts a port-forward to `localhost:2480`.
+* `stop.sh` -- terminates the port-forward, runs `helm uninstall`, and destroys the kind cluster.
+* `test.sh` -- validates that the cluster is functional.
+* `values.yaml` -- the values overrides used by `start.sh`. Note that this file wraps overrides under a top-level `arcadedb:` key because it consumes the chart as a *subchart*; when installing the chart directly (the path documented above), use the same overrides at the top level.
+
+Use this repository as a starting point for your own setup and as a reproducible bug-report environment.

--- a/src/main/asciidoc/how-to/operations/kubernetes.adoc
+++ b/src/main/asciidoc/how-to/operations/kubernetes.adoc
@@ -511,20 +511,232 @@ autoscaling:
 [[kubernetes-values-security]]
 ====== Security context
 
+The chart sets a restrictive security posture by default.
+At the pod level, `podSecurityContext` ensures all processes run as a non-root user and that the filesystem group matches the `arcadedb` user (`1000`) created in the Docker image, so mounted volumes are writable without `chmod`.
+At the container level, `securityContext` pins the UID/GID to `1000`, blocks privilege escalation, and drops all Linux capabilities — the server needs none.
+
+[%header,cols="2,1,4"]
+|===
+|Key | Default | Description
+
+|`podSecurityContext.runAsNonRoot` | `true` | Require that the pod's entry-point process runs as a non-root UID. Kubernetes rejects the pod if the image's `USER` is `0`.
+|`podSecurityContext.fsGroup` | `1000` | Supplemental GID applied to mounted volumes. Set to match the `arcadedb` user so PVC data directories are writable by the container process.
+|`securityContext.runAsUser` | `1000` | UID used by the container process. Matches the `arcadedb` user in the image.
+|`securityContext.runAsGroup` | `1000` | Primary GID used by the container process.
+|`securityContext.allowPrivilegeEscalation` | `false` | Prevents the container process from gaining more privileges than its parent (blocks `setuid` binaries, no `CAP_SYS_ADMIN`, etc.).
+|`securityContext.capabilities.drop` | `[ALL]` | Drops every Linux capability from the container. ArcadeDB requires none of the default capabilities.
+|===
+
+Example override (adding `readOnlyRootFilesystem` for maximum hardening — ArcadeDB writes only to its data directory, which is a mounted volume):
+
+[source,yaml]
+----
+podSecurityContext:
+  runAsNonRoot: true
+  fsGroup: 1000
+securityContext:
+  runAsUser: 1000
+  runAsGroup: 1000
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: [ALL]
+  readOnlyRootFilesystem: true
+----
+
+[NOTE]
+====
+`readOnlyRootFilesystem: true` is not set by the chart's default but is safe to add when persistence is enabled — ArcadeDB writes database files to the PVC mount path, not to the container root filesystem.
+If you run without persistence (`persistence.enabled: false`), omit this flag because the container writes databases to the root filesystem.
+====
+
 [[kubernetes-values-service-account]]
 ====== Service account
+
+The chart creates a dedicated `ServiceAccount` for ArcadeDB pods by default.
+Disable creation and supply an existing `ServiceAccount` name when you manage service accounts outside Helm — for example, to attach an IRSA annotation (AWS EKS) or a Workload Identity annotation (GKE) that grants the pod cloud-provider permissions such as reading secrets from AWS Secrets Manager or Google Secret Manager.
+
+[%header,cols="2,1,4"]
+|===
+|Key | Default | Description
+
+|`serviceAccount.create` | `true` | Create a `ServiceAccount` as part of the release. Set to `false` to reuse a pre-existing account (supply its name in `serviceAccount.name`).
+|`serviceAccount.automount` | `false` | Mount the service account token into pods. ArcadeDB does not call the Kubernetes API, so the token is unnecessary; keeping it unmounted reduces the attack surface.
+|`serviceAccount.annotations` | `{}` | Annotations applied to the `ServiceAccount` object. Used for cloud-provider workload identity (e.g. `eks.amazonaws.com/role-arn` for IRSA, `iam.gke.io/gcp-service-account` for GKE Workload Identity).
+|`serviceAccount.name` | `""` | Name of the `ServiceAccount` to use. When empty and `serviceAccount.create` is `true`, the chart generates a name from the release.
+|===
+
+Example override (reusing an existing service account with a GKE Workload Identity annotation):
+
+[source,yaml]
+----
+serviceAccount:
+  create: false
+  name: arcadedb-wi-sa
+  annotations:
+    iam.gke.io/gcp-service-account: arcadedb@my-gcp-project.iam.gserviceaccount.com
+----
 
 [[kubernetes-values-scheduling]]
 ====== Scheduling
 
+`nodeSelector`, `tolerations`, and `affinity` control which nodes the ArcadeDB pods are placed on.
+The chart ships with a default `podAntiAffinity` rule (weight 100) that prefers scheduling each pod on a different node — the most useful pattern for Raft-based HA clusters, since it distributes quorum peers across failure domains and keeps the cluster alive when a single node goes down.
+
+[%header,cols="2,1,4"]
+|===
+|Key | Default | Description
+
+|`nodeSelector` | `{}` | Map of node labels that pods must match. Use to restrict ArcadeDB to a specific node pool (e.g. `cloud.google.com/gke-nodepool: db-pool`).
+|`tolerations` | `[]` | List of Kubernetes `Toleration` objects. Needed when ArcadeDB should run on tainted nodes (e.g. dedicated database nodes marked with `NoSchedule`).
+|`affinity` | (pod anti-affinity — see below) | Full `affinity` stanza. The default contains a `preferredDuringSchedulingIgnoredDuringExecution` pod anti-affinity rule that spreads pods across distinct hostnames. Override the entire key to replace it.
+|===
+
+The chart's built-in `affinity` default:
+
+[source,yaml]
+----
+affinity:
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+              - key: app.kubernetes.io/name
+                operator: In
+                values:
+                  - arcadedb
+          topologyKey: kubernetes.io/hostname
+----
+
+Example override (required anti-affinity across availability zones — stricter than the default preference-based rule):
+
+[source,yaml]
+----
+affinity:
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+            - key: app.kubernetes.io/instance
+              operator: In
+              values:
+                - my-arcadedb
+        topologyKey: topology.kubernetes.io/zone
+----
+
+[NOTE]
+====
+Switching from `preferredDuringScheduling` to `requiredDuringScheduling` means Kubernetes will leave pods `Pending` rather than co-locate them when there are fewer zones than replicas.
+Verify that your cluster has at least as many zones (or nodes) as `replicaCount` before using `required` rules.
+====
+
 [[kubernetes-values-pod-metadata]]
 ====== Pod metadata
+
+`podAnnotations` and `podLabels` attach metadata directly to the pod objects created by the `StatefulSet`.
+Annotations are the standard integration point for cluster tooling: Prometheus scrape configuration, secret injection sidecars (Vault Agent, External Secrets), and service mesh proxy injection all rely on pod annotations.
+Labels supplement the chart-generated selectors and are useful for observability grouping, cost allocation, or policy enforcement tools that filter by label.
+
+[%header,cols="2,1,4"]
+|===
+|Key | Default | Description
+
+|`podAnnotations` | `{}` | Annotations applied to every pod. Common uses: Prometheus scrape hints, Vault Agent injection, Datadog APM tracing, Istio sidecar policy.
+|`podLabels` | `{}` | Extra labels applied to every pod. Merged with the chart-generated labels (`app.kubernetes.io/*`). Useful for cost-allocation labels, Cilium network policies that match on custom labels, or PodDisruptionBudget selectors.
+|===
+
+Example override (Prometheus scrape annotations):
+
+[source,yaml]
+----
+podAnnotations:
+  prometheus.io/scrape: "true"
+  prometheus.io/port: "2480"
+  prometheus.io/path: "/api/v1/server"
+----
+
+[NOTE]
+====
+The Prometheus annotations shown above work with the community `prometheus/prometheus` scrape-config style.
+If you use the Prometheus Operator (`ServiceMonitor`/`PodMonitor` CRDs), configure a `PodMonitor` resource instead and omit these annotations.
+Enable the Prometheus plugin (`arcadedb.plugins.prometheus.enabled: true`) to expose the `/metrics` endpoint.
+====
 
 [[kubernetes-values-network-policy]]
 ====== Network policy
 
+Setting `networkPolicy.enabled: true` creates a Kubernetes `NetworkPolicy` that restricts traffic to and from ArcadeDB pods: the HTTP port (2480) accepts connections from any pod in the cluster, while the Raft gRPC port (2434) is locked down to ArcadeDB pods only.
+This requires a CNI plugin that enforces `NetworkPolicy` resources — Calico, Cilium, Weave Net, and most managed Kubernetes offerings (GKE, EKS with VPC CNI + policy, ASK Azure CNI) support this; vanilla `kubenet` does not.
+
+[%header,cols="2,1,4"]
+|===
+|Key | Default | Description
+
+|`networkPolicy.enabled` | `false` | Create `NetworkPolicy` resources for the release. When `true`, inbound HTTP (2480) is permitted from all pods in the cluster; Raft gRPC (2434) is restricted to pods belonging to the same ArcadeDB release.
+|===
+
+Example override:
+
+[source,yaml]
+----
+networkPolicy:
+  enabled: true
+----
+
+[IMPORTANT]
+====
+Enabling `networkPolicy` has no effect if your cluster's CNI does not enforce `NetworkPolicy` objects.
+Verify enforcement with `kubectl auth can-i create networkpolicies` and test the policy with a known-blocked source after enabling it.
+====
+
 [[kubernetes-values-extras]]
 ====== Extras
+
+The escape-hatch keys let you attach resources that the named chart values do not cover: extra Kubernetes manifests rendered alongside the chart, extra volumes and volume mounts injected into the container spec, and additional `volumeClaimTemplates` for the `StatefulSet`.
+These are advanced options intended for cases where a named value does not exist — for example, mounting a `ConfigMap` as a configuration file, adding a sidecar's shared `emptyDir`, or provisioning a separate PVC for WAL logs.
+
+[%header,cols="2,1,4"]
+|===
+|Key | Default | Description
+
+|`extraManifests` | `{}` | Map of arbitrary Kubernetes manifests rendered as part of the Helm release. Use to co-deploy `ConfigMap`, `ExternalSecret`, or other objects that must live in the same namespace and lifecycle as the chart.
+|`volumes` | `[]` | List of extra `volume` entries added to the pod spec. Pair with `volumeMounts` to expose the volume inside the container.
+|`volumeMounts` | `[]` | List of extra `volumeMount` entries added to the ArcadeDB container spec. The `mountPath` must not overlap with the persistence mount (`/home/arcadedb/databases`).
+|`volumeClaimTemplates` | `[]` | Extra `volumeClaimTemplates` for the `StatefulSet` (e.g. a dedicated PVC for WAL files, replication logs, or backups). The primary database PVC is controlled by `persistence.enabled` — see <<kubernetes-values-persistence,Persistence>>.
+|===
+
+Example override (mounting an extra `ConfigMap` as a config file):
+
+[source,yaml]
+----
+volumes:
+  - name: custom-config
+    configMap:
+      name: arcadedb-extra-config
+volumeMounts:
+  - name: custom-config
+    mountPath: /home/arcadedb/config/custom.json
+    subPath: custom.json
+    readOnly: true
+----
+
+The corresponding `ConfigMap` can be co-deployed via `extraManifests`:
+
+[source,yaml]
+----
+extraManifests:
+  arcadedb-extra-config:
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: arcadedb-extra-config
+    data:
+      custom.json: |
+        {
+          "key": "value"
+        }
+----
 
 [[kubernetes-operate]]
 ===== Operating the cluster

--- a/src/main/asciidoc/how-to/operations/kubernetes.adoc
+++ b/src/main/asciidoc/how-to/operations/kubernetes.adoc
@@ -131,8 +131,46 @@ The pods are named `my-arcadedb-0`, `my-arcadedb-1`, ... and reach the `Ready` s
 [[kubernetes-values]]
 ===== Configuration reference
 
+The values exposed by the chart are grouped below.
+This reference targets chart version *26.4.2*; confirm the current set against your installation with:
+
+[source,shell]
+----
+helm show values arcadedb/arcadedb
+----
+
+The complete and authoritative source is the chart's https://github.com/ArcadeData/arcadedb-helm/blob/main/charts/arcadedb/values.yaml[`values.yaml`].
+The example snippets below show keys at the top level (the chart is installed directly as `arcadedb/arcadedb`); if you consume the chart as a *subchart* under a parent named `arcadedb`, wrap each snippet under a top-level `arcadedb:` key.
+
 [[kubernetes-values-image]]
 ====== Image
+
+Selects the container image, pull policy, and pull secrets.
+Override `image.tag` to pin to a specific ArcadeDB release; otherwise the chart's `appVersion` is used.
+
+[%header,cols="2,1,4"]
+|===
+|Key | Default | Description
+
+|`image.registry` | `arcadedata` | Container registry hosting the image
+|`image.repository` | `arcadedb` | Image repository name
+|`image.tag` | (chart `appVersion`) | Image tag; pin to a specific ArcadeDB version for reproducible deployments
+|`image.pullPolicy` | `IfNotPresent` | Kubernetes image pull policy
+|`imagePullSecrets` | `[]` | List of `Secret` references for private registries
+|`nameOverride` | `""` | Overrides the chart name used in resource names
+|`fullnameOverride` | `""` | Overrides the fully-qualified app name used in resource names
+|===
+
+Example override:
+
+[source,yaml]
+----
+image:
+  tag: "26.4.2"
+  pullPolicy: IfNotPresent
+imagePullSecrets:
+  - name: my-registry-secret
+----
 
 [[kubernetes-values-replicas]]
 ====== Replicas

--- a/src/main/asciidoc/how-to/operations/kubernetes.adoc
+++ b/src/main/asciidoc/how-to/operations/kubernetes.adoc
@@ -231,7 +231,7 @@ These keys control where ArcadeDB stores databases inside the container, which d
 
 |`arcadedb.databaseDirectory` | `/home/arcadedb/databases` | Path inside the container where database files are stored. Must match the `persistence` mount path if a PVC is used.
 |`arcadedb.defaultDatabases` | `""` | Databases to create automatically at first startup. Use the form `Name[user:password]`, e.g. `Universe[admin:secret]`. Empty string means no databases are pre-created.
-|`arcadedb.extraCommands` | `["-Darcadedb.server.mode=production"]` | List of additional JVM `-D` arguments appended to the ArcadeDB startup command.
+|`arcadedb.extraCommands` | `[-Darcadedb.server.mode=production]` | List of additional JVM `-D` arguments appended to the ArcadeDB startup command.
 |`arcadedb.extraEnvironment` | `[]` | List of extra environment variables (in `name`/`value` map form) injected into the container.
 |===
 
@@ -252,21 +252,21 @@ arcadedb:
 ====== Plugins
 
 ArcadeDB supports multiple wire protocols alongside its native HTTP API; each protocol is enabled by adding the corresponding key under `arcadedb.plugins`.
-The chart ships with named slots for `gremlin`, `postgres`, `mongo`, `redis`, and `prometheus`, plus an open `custom` slot for user-supplied plugins.
+The chart ships with named slots for `gremlin`, `postgres`, `mongo`, `redis`, and `prometheus`, plus support for any user-supplied key (e.g. `myPlugin`) for custom plugins.
 By default, `arcadedb.plugins` is an empty map (`{}`), meaning no wire-protocol plugins are activated.
 
 [%header,cols="2,1,4"]
 |===
 |Key | Default | Description
 
-|`arcadedb.plugins.gremlin.enabled` | (absent) | Enable the Apache TinkerPop Gremlin server plugin on port `8182`.
-|`arcadedb.plugins.gremlin.port` | `8182` | Port the Gremlin plugin listens on.
-|`arcadedb.plugins.postgres.enabled` | (absent) | Enable the PostgreSQL wire-protocol plugin on port `5432`.
-|`arcadedb.plugins.postgres.port` | `5432` | Port the PostgreSQL plugin listens on.
-|`arcadedb.plugins.mongo.enabled` | (absent) | Enable the MongoDB wire-protocol plugin on port `27017`.
-|`arcadedb.plugins.mongo.port` | `27017` | Port the MongoDB plugin listens on.
-|`arcadedb.plugins.redis.enabled` | (absent) | Enable the Redis wire-protocol plugin on port `6379`.
-|`arcadedb.plugins.redis.port` | `6379` | Port the Redis plugin listens on.
+|`arcadedb.plugins.gremlin.enabled` | (absent) | Enable the Apache TinkerPop Gremlin server plugin.
+|`arcadedb.plugins.gremlin.port` | (absent — see example) | Port the Gremlin plugin listens on; conventionally `8182`.
+|`arcadedb.plugins.postgres.enabled` | (absent) | Enable the PostgreSQL wire-protocol plugin.
+|`arcadedb.plugins.postgres.port` | (absent — see example) | Port the PostgreSQL plugin listens on; conventionally `5432`.
+|`arcadedb.plugins.mongo.enabled` | (absent) | Enable the MongoDB wire-protocol plugin.
+|`arcadedb.plugins.mongo.port` | (absent — see example) | Port the MongoDB plugin listens on; conventionally `27017`.
+|`arcadedb.plugins.redis.enabled` | (absent) | Enable the Redis wire-protocol plugin.
+|`arcadedb.plugins.redis.port` | (absent — see example) | Port the Redis plugin listens on; conventionally `6379`.
 |`arcadedb.plugins.prometheus.enabled` | (absent) | Enable the Prometheus metrics endpoint.
 |===
 

--- a/src/main/asciidoc/how-to/operations/kubernetes.adoc
+++ b/src/main/asciidoc/how-to/operations/kubernetes.adoc
@@ -1,89 +1,81 @@
 [[kubernetes]]
 ==== Kubernetes
 
-Before starting the Kubernetes (K8S) cluster, set ArcadeDB Server root password as a secret (replace <password> with the root password you want to use):
+ArcadeDB officially supports deployment on Kubernetes via the https://github.com/ArcadeData/arcadedb-helm[arcadedb-helm] chart, published at `https://helm.arcadedb.com/`.
+The chart deploys ArcadeDB as a `StatefulSet` and, when `replicaCount` is greater than 1, automatically configures a Raft-based <<howto-high-availability,High Availability>> cluster.
+The reference for the configuration values below targets chart version *26.4.2*; confirm against your installation with `helm show values arcadedb/arcadedb`.
 
-[source,shell]
-----
-$ kubectl create secret generic arcadedb-credentials --from-literal=rootPassword='<password>'
-----
+[[kubernetes-prerequisites]]
+===== Prerequisites
 
-This will set the password in the `rootPassword` environment variable. The ArcadeDB server will use this password for the `root` user.
+[[kubernetes-quickstart]]
+===== Quickstart with kind
 
-Now you can start a Kubernetes cluster with 3 servers by using the default configuration:
+[[kubernetes-install]]
+===== Installing the chart
 
-[source,shell]
-----
-$ kubectl apply -f config/arcadedb-statefulset.yaml
-----
+[[kubernetes-values]]
+===== Configuration reference
 
-For more information on ArcadeDB Kubernetes config https://github.com/ArcadeData/arcadedb/blob/main/package/src/main/config/arcadedb-statefulset.yaml[please check].
+[[kubernetes-values-image]]
+====== Image
 
-In order to scale up or down with the number of replicas, use this:
+[[kubernetes-values-replicas]]
+====== Replicas
 
-[source,shell]
-----
-$ kubectl scale statefulsets arcadedb-server --replicas=<new-number-of-replicas>
-----
+[[kubernetes-values-credentials]]
+====== Credentials
 
-Where the value of `<new-number-of-replicas>` is the new number of replicas. Example:
+[[kubernetes-values-database]]
+====== Database
 
-[source,shell]
-----
-$ kubectl scale statefulsets arcadedb-server --replicas=3
-----
+[[kubernetes-values-plugins]]
+====== Plugins
 
-Scaling up and down doesn't affect current workload. There are no pauses when a server enters/exits from the cluster.
+[[kubernetes-values-service]]
+====== Service
 
-===== Helm Charts
+[[kubernetes-values-ingress]]
+====== Ingress
 
-To facilitate the deployment of ArcadeDB on a Kubernetes cluster a Helm chart can be used.
-To install the template chart with the release name `my-arcadedb` enter:
+[[kubernetes-values-persistence]]
+====== Persistence
 
-[source,shell]
-----
-helm install my-arcadedb ./arcadedb
-----
+[[kubernetes-values-resources]]
+====== Resources
 
-The command deploys ArcadeDB on the Kubernetes cluster using the default configuration.
-To uninstall/delete the `my-arcadedb` deployment:
+[[kubernetes-values-probes]]
+====== Probes
 
-[source,shell]
-----
-helm uninstall my-arcadedb
-----
+[[kubernetes-values-autoscaling]]
+====== Autoscaling
 
-The command removes all the Kubernetes components associated with the chart and deletes the release.
-Details about the configurable parameters of the template chart, as well as persistence, ingress, and resource, see the dedicated https://github.com/ArcadeData/arcadedb/blob/main/k8s/helm/README.md[README].
+[[kubernetes-values-security]]
+====== Security context
 
+[[kubernetes-values-serviceaccount]]
+====== Service account
+
+[[kubernetes-values-scheduling]]
+====== Scheduling
+
+[[kubernetes-values-podmetadata]]
+====== Pod metadata
+
+[[kubernetes-values-networkpolicy]]
+====== Network policy
+
+[[kubernetes-values-extras]]
+====== Extras
+
+[[kubernetes-operate]]
+===== Operating the cluster
+
+[[kubernetes-ha]]
+===== High Availability on Kubernetes
+
+[[kubernetes-troubleshooting]]
 ===== Troubleshooting
 
-The most common issue with using K8S is with the setting of the root password for the server (see at the beginning of this section).
-
-Following are some useful commands for troubleshooting issues with ArcadeDB and Kubernetes.
-
-Display the status of a pod:
-
-[source,shell]
-----
-$ kubectl describe pod arcadedb-0
-----
-
-Replace "arcadedb-0" with the server container you want to use.
-
-To display the logs of the first server:
-
-[source,shell]
-----
-$ kubectl logs arcadedb-0
-----
-
-Replace "arcadedb-0" with the server container you want to use.
-
-To remove all the containers and restart the cluster again, execute these 2 commands:
-
-[source,shell]
-----
-$ kubectl delete all --all --namespace default
-$ kubectl apply -f config/arcadedb-statefulset.yaml
-----
+[[kubernetes-reference-deployment]]
+===== Reference deployment

--- a/src/main/asciidoc/how-to/operations/kubernetes.adoc
+++ b/src/main/asciidoc/how-to/operations/kubernetes.adoc
@@ -799,6 +799,30 @@ Delete it explicitly if no longer needed.
 [[kubernetes-ha]]
 ===== High Availability on Kubernetes
 
+ArcadeDB on Kubernetes uses the standard `StatefulSet` + headless `Service` pattern (the same pattern used by `etcd`, CockroachDB, and Apache Ozone).
+The chart pre-computes the full peer list from `replicaCount` and injects it into each pod via environment variables, so users do not configure `arcadedb.ha.serverList` by hand.
+
+The chart sets the equivalent of:
+
+[source,properties]
+----
+arcadedb.ha.enabled=true
+arcadedb.ha.k8s=true
+arcadedb.ha.k8sSuffix=.my-arcadedb.arcadedb.svc.cluster.local
+arcadedb.ha.serverList=my-arcadedb-0.my-arcadedb.arcadedb.svc.cluster.local:2434:2480,my-arcadedb-1.my-arcadedb.arcadedb.svc.cluster.local:2434:2480,my-arcadedb-2.my-arcadedb.arcadedb.svc.cluster.local:2434:2480
+----
+
+(Substitute your release name and namespace.)
+
+*Auto-join on scale-up* (since `26.4.1`)::
+When `arcadedb.ha.k8s=true` and a new pod starts without an existing Raft storage directory, the server automatically joins the existing cluster via the Raft `SetConfiguration(ADD)` admin API.
+This enables zero-downtime scale-up: `helm upgrade --set replicaCount=N` (or `kubectl scale statefulset`) adds new pods that join the existing cluster without restarting any existing peer.
+
+*Auto-leave on scale-down*::
+The chart installs a `preStop` hook that calls `POST /api/v1/cluster/leave` so the terminating pod cleanly transfers leadership (if it holds it) and removes itself from the Raft group before shutdown.
+
+For the rest of the Raft semantics -- quorum, named peers, snapshot threshold, election timeouts, cluster token, replication failure handling -- see <<howto-high-availability,High Availability>>.
+
 [[kubernetes-troubleshooting]]
 ===== Troubleshooting
 

--- a/src/main/asciidoc/how-to/operations/kubernetes.adoc
+++ b/src/main/asciidoc/how-to/operations/kubernetes.adoc
@@ -105,7 +105,7 @@ kubectl create secret generic arcadedb-credentials \
 ----
 
 . Prepare a `values.yaml` override file that fits your environment.
-At a minimum, set `replicaCount`, `image.tag`, and the `credentials.rootPassword.secret` block.
+At a minimum, set `replicaCount`, `image.tag`, and the `arcadedb.credentials.rootPassword.secret` block.
 See the <<kubernetes-values,configuration reference>> for the full set of options including persistence, ingress, resources, autoscaling, and security context.
 
 . Install the chart:
@@ -198,7 +198,7 @@ replicaCount: 3
 ====== Credentials
 
 The chart never stores the root password in its own values; it reads it from a Kubernetes `Secret` at install time.
-If `credentials.rootPassword.secret.name` is `null`, a 32-character random password is auto-generated in a `Secret` named `arcadedb-credentials-secret` — note that GitOps tools such as ArgoCD regenerate this secret on every render, so supply your own secret for production.
+If `arcadedb.credentials.rootPassword.secret.name` is `null`, a 32-character random password is auto-generated in a `Secret` named `arcadedb-credentials-secret` — note that GitOps tools such as ArgoCD regenerate this secret on every render, so supply your own secret for production.
 Pods that start without a resolvable secret crash-loop immediately; see <<kubernetes-troubleshooting,Troubleshooting>> for the symptom and fix.
 
 [%header,cols="2,1,4"]
@@ -809,7 +809,7 @@ The chart sets the equivalent of:
 arcadedb.ha.enabled=true
 arcadedb.ha.k8s=true
 arcadedb.ha.k8sSuffix=.my-arcadedb.arcadedb.svc.cluster.local
-arcadedb.ha.serverList=my-arcadedb-0.my-arcadedb.arcadedb.svc.cluster.local:2434,my-arcadedb-1.my-arcadedb.arcadedb.svc.cluster.local:2434,my-arcadedb-2.my-arcadedb.arcadedb.svc.cluster.local:2434
+arcadedb.ha.serverList=my-arcadedb-0.my-arcadedb.arcadedb.svc.cluster.local:2434:2480,my-arcadedb-1.my-arcadedb.arcadedb.svc.cluster.local:2434:2480,my-arcadedb-2.my-arcadedb.arcadedb.svc.cluster.local:2434:2480
 ----
 
 (Substitute your release name and namespace.)
@@ -827,7 +827,7 @@ For the rest of the Raft semantics -- quorum, named peers, snapshot threshold, e
 ===== Troubleshooting
 
 The most common deployment failure is a missing or incorrectly named `rootPassword` `Secret` -- pods crash-loop with an authentication-related error in the log.
-Verify the secret exists and that the chart's `credentials.rootPassword.secret.name` and `.key` match it.
+Verify the secret exists and that the chart's `arcadedb.credentials.rootPassword.secret.name` and `.key` match it.
 
 Inspect a pod's events:
 

--- a/src/main/asciidoc/how-to/operations/kubernetes.adoc
+++ b/src/main/asciidoc/how-to/operations/kubernetes.adoc
@@ -175,14 +175,114 @@ imagePullSecrets:
 [[kubernetes-values-replicas]]
 ====== Replicas
 
+`replicaCount` controls how many ArcadeDB pods the `StatefulSet` runs.
+A single replica (`1`) gives a standalone instance; three replicas is the smallest cluster that tolerates one node failure under Raft majority quorum.
+See <<kubernetes-ha,High Availability on Kubernetes>> for the implications of running a multi-replica cluster.
+
+[%header,cols="2,1,4"]
+|===
+|Key | Default | Description
+
+|`replicaCount` | `1` | Number of ArcadeDB pods. Values greater than 1 enable Raft HA automatically; the minimum recommended HA size is 3.
+|===
+
+Example override:
+
+[source,yaml]
+----
+replicaCount: 3
+----
+
 [[kubernetes-values-credentials]]
 ====== Credentials
+
+The chart never stores the root password in its own values; it reads it from a Kubernetes `Secret` at install time.
+If `credentials.rootPassword.secret.name` is `null`, a 32-character random password is auto-generated in a `Secret` named `arcadedb-credentials-secret` — note that GitOps tools such as ArgoCD regenerate this secret on every render, so supply your own secret for production.
+Pods that start without a resolvable secret crash-loop immediately; see <<kubernetes-troubleshooting,Troubleshooting>> for the symptom and fix.
+
+[%header,cols="2,1,4"]
+|===
+|Key | Default | Description
+
+|`arcadedb.credentials.rootPassword.secret.name` | `null` | Name of an existing `Secret` containing the root password. `null` triggers auto-generation.
+|`arcadedb.credentials.rootPassword.secret.key` | `null` | Key within the named `Secret` whose value is the root password.
+|===
+
+Create the secret first (see the <<kubernetes-quickstart,Quickstart>> for the full command), then reference it in your `values.yaml`:
+
+[source,yaml]
+----
+arcadedb:
+  credentials:
+    rootPassword:
+      secret:
+        name: arcadedb-credentials
+        key: rootPassword
+----
 
 [[kubernetes-values-database]]
 ====== Database
 
+These keys control where ArcadeDB stores databases inside the container, which databases to create at startup, additional JVM arguments, and arbitrary environment variables passed to the container process.
+
+[%header,cols="2,1,4"]
+|===
+|Key | Default | Description
+
+|`arcadedb.databaseDirectory` | `/home/arcadedb/databases` | Path inside the container where database files are stored. Must match the `persistence` mount path if a PVC is used.
+|`arcadedb.defaultDatabases` | `""` | Databases to create automatically at first startup. Use the form `Name[user:password]`, e.g. `Universe[admin:secret]`. Empty string means no databases are pre-created.
+|`arcadedb.extraCommands` | `["-Darcadedb.server.mode=production"]` | List of additional JVM `-D` arguments appended to the ArcadeDB startup command.
+|`arcadedb.extraEnvironment` | `[]` | List of extra environment variables (in `name`/`value` map form) injected into the container.
+|===
+
+Example override:
+
+[source,yaml]
+----
+arcadedb:
+  extraCommands:
+    - -Darcadedb.server.mode=production
+    - -Darcadedb.tx.walFiles=2
+  extraEnvironment:
+    - name: JAVA_TOOL_OPTIONS
+      value: "-XX:+UseG1GC"
+----
+
 [[kubernetes-values-plugins]]
 ====== Plugins
+
+ArcadeDB supports multiple wire protocols alongside its native HTTP API; each protocol is enabled by adding the corresponding key under `arcadedb.plugins`.
+The chart ships with named slots for `gremlin`, `postgres`, `mongo`, `redis`, and `prometheus`, plus an open `custom` slot for user-supplied plugins.
+By default, `arcadedb.plugins` is an empty map (`{}`), meaning no wire-protocol plugins are activated.
+
+[%header,cols="2,1,4"]
+|===
+|Key | Default | Description
+
+|`arcadedb.plugins.gremlin.enabled` | (absent) | Enable the Apache TinkerPop Gremlin server plugin on port `8182`.
+|`arcadedb.plugins.gremlin.port` | `8182` | Port the Gremlin plugin listens on.
+|`arcadedb.plugins.postgres.enabled` | (absent) | Enable the PostgreSQL wire-protocol plugin on port `5432`.
+|`arcadedb.plugins.postgres.port` | `5432` | Port the PostgreSQL plugin listens on.
+|`arcadedb.plugins.mongo.enabled` | (absent) | Enable the MongoDB wire-protocol plugin on port `27017`.
+|`arcadedb.plugins.mongo.port` | `27017` | Port the MongoDB plugin listens on.
+|`arcadedb.plugins.redis.enabled` | (absent) | Enable the Redis wire-protocol plugin on port `6379`.
+|`arcadedb.plugins.redis.port` | `6379` | Port the Redis plugin listens on.
+|`arcadedb.plugins.prometheus.enabled` | (absent) | Enable the Prometheus metrics endpoint.
+|===
+
+Example override (enabling the PostgreSQL and MongoDB wire protocols):
+
+[source,yaml]
+----
+arcadedb:
+  plugins:
+    postgres:
+      enabled: true
+      port: 5432
+    mongo:
+      enabled: true
+      port: 27017
+----
 
 [[kubernetes-values-service]]
 ====== Service

--- a/src/main/asciidoc/how-to/operations/kubernetes.adoc
+++ b/src/main/asciidoc/how-to/operations/kubernetes.adoc
@@ -741,6 +741,61 @@ extraManifests:
 [[kubernetes-operate]]
 ===== Operating the cluster
 
+====== Scaling
+
+Use `helm upgrade` to change the replica count persistently:
+
+[source,shell]
+----
+helm upgrade my-arcadedb arcadedb/arcadedb \
+  --namespace arcadedb \
+  --reuse-values \
+  --set replicaCount=5
+----
+
+`kubectl scale statefulset` also works for an immediate, one-off change:
+
+[source,shell]
+----
+kubectl -n arcadedb scale statefulset my-arcadedb --replicas=5
+----
+
+A `kubectl scale` change is reverted on the next `helm upgrade` because Helm reapplies the `replicaCount` from the chart values.
+For persistent changes, prefer `helm upgrade --set replicaCount=N` (or update the values file).
+
+Scaling does not pause the workload.
+New pods auto-join the Raft cluster, and pods removed during scale-down auto-leave via the `preStop` hook (see <<kubernetes-ha,High Availability on Kubernetes>>).
+
+====== Upgrading the chart
+
+[source,shell]
+----
+helm repo update
+helm upgrade my-arcadedb arcadedb/arcadedb \
+  --namespace arcadedb \
+  --reuse-values
+----
+
+Pin `image.tag` to a specific ArcadeDB version for reproducible upgrades.
+
+====== Uninstalling
+
+[source,shell]
+----
+helm uninstall my-arcadedb --namespace arcadedb
+----
+
+Persistent volume claims *survive uninstall* by design.
+To remove them too:
+
+[source,shell]
+----
+kubectl -n arcadedb delete pvc -l app.kubernetes.io/name=arcadedb
+----
+
+The `Secret` holding the root password is not managed by Helm and is also retained.
+Delete it explicitly if no longer needed.
+
 [[kubernetes-ha]]
 ===== High Availability on Kubernetes
 


### PR DESCRIPTION
## Summary

- Rewrite `src/main/asciidoc/how-to/operations/kubernetes.adoc` around the official `arcadedb-helm` chart (v26.4.2, published at `https://helm.arcadedb.com/`). The legacy raw `kubectl apply -f arcadedb-statefulset.yaml` flow is removed; Helm is now the sole documented install path.
- Add a kind-based 5-minute quickstart, a production install walkthrough, a comprehensive `values.yaml` reference covering all 17 chart value groups (image, replicas, credentials, database, plugins, service, ingress, persistence, resources, probes, autoscaling, security context, service account, scheduling, pod metadata, network policy, extras), an operate-the-cluster section (scaling, upgrading, uninstalling), HA-on-Kubernetes content with auto-join/auto-leave, troubleshooting, and a link to the `arcadedb-deployments` reference repo.
- Consolidate the K8s/HA content from `ha.adoc` (lines 341–360) into the new `kubernetes-ha` section; `ha.adoc` now links forward.

## Design and plan

- Spec: `docs/superpowers/specs/2026-05-07-kubernetes-helm-refactor-design.md`
- Plan: `docs/superpowers/plans/2026-05-07-kubernetes-helm-refactor.md`

## Notable corrections caught during review

- Auto-generated `<<ha,...>>` cross-ref in the spec was a dead link; fixed to `<<howto-high-availability,...>>` (the actual anchor in `ha.adoc`).
- Plugin port defaults were initially listed as concrete numbers (`8182`, `5432`, ...); these are commented examples in the chart, not actual defaults — moved to descriptions with conventional-port wording.
- Quickstart `values.yaml` originally placed `credentials:` at top level (silently ignored by Helm); fixed to wrap under `arcadedb:` matching the chart's actual key path.
- HA `serverList` example was `host:rpcPort:httpPort`; the chart's `nodenames` helper emits `host:rpcPort` only — corrected.
- Prometheus scrape annotation example pointed to `/api/v1/server`; the metrics endpoint is `/metrics` — corrected.
- `volumeClaimTemplates` was duplicated across Persistence and Extras tables; kept in Extras (where it belongs as a top-level chart value).

## Test plan

- [x] `python3 docs-validator.py` passes (anchors, naming, cross-references)
- [x] `mvn generate-resources` builds the single-page HTML without Asciidoctor errors
- [x] `mvn -Pgenerate-pdf-doc generate-resources` builds `ArcadeDB-Manual.pdf` (34 MB)
- [x] `npm ci && bash scripts/migrate.sh && npm run build` builds the Antora site; the rendered Kubernetes page is at `build/site/arcadedb/how-to/operations/kubernetes.html`
- [x] No anchor collisions: every new `kubernetes-*` anchor is unique
- [x] Cross-references resolve in both directions (`kubernetes.adoc` → `howto-high-availability`, `ha.adoc` → `kubernetes-ha`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)