### PR TITLE
docs: document ha.appendElementLimit setting

### DIFF
--- a/src/main/asciidoc/reference/settings.adoc
+++ b/src/main/asciidoc/reference/settings.adoc
@@ -114,6 +114,7 @@ The following plugins are available for ArcadeDB Server:
 |Name|Description|Type|Default Value
 |`backup.enabled`|State of backup lock. Disable for increased performance of massive insertions.|Boolean|True
 |`ha.appendBufferSize`|AppendEntries batch byte limit for replication (e.g. '4MB'). _Since v26.4.1_|String|4MB
+|`ha.appendElementLimit`|Maximum number of Raft log entries per AppendEntries batch. Bounds the per-batch in-memory footprint on the follower during catch-up resync, where many batches may queue before the state machine can apply them. Lowering this value reduces peak heap pressure on followers catching up from a far-behind state. The byte limit (`ha.appendBufferSize`) remains the dominant per-batch heap bound; this element count is the secondary cap that governs when entries are small enough that many fit under the byte limit. Must be a positive integer (>= 1). _Since v26.7.1_|Integer|64
 |`ha.clientElectionRetryCount`|Number of retries performed by RemoteDatabase after receiving HTTP 503 NeedRetryException during an election. _Since v26.4.1_|Integer|3
 |`ha.clientElectionRetryDelayMs`|Delay in ms between RemoteDatabase election retries. _Since v26.4.1_|Long|2000
 |`ha.bootstrapFromLocalDatabase`|When true (default), at first cluster formation peers exchange `(fingerprint, lastTxId)` per database; the highest-`lastTxId` peer is elected as bootstrap source via leadership transfer. Matching peers bootstrap locally with zero bytes transferred; mismatched peers reinstall the leader-shipped full snapshot. _Since v26.5.1_|Boolean|true


### PR DESCRIPTION
## Summary

Documents the new `arcadedb.ha.appendElementLimit` configuration parameter (default `64`) introduced in ArcadeData/arcadedb#4753.

The setting caps the number of Raft log entries per AppendEntries batch, bounding the per-batch in-memory footprint on a follower during catch-up resync. It acts as a secondary cap to the dominant byte limit (`ha.appendBufferSize`, 4MB default).

## Changes

- Added an `ha.appendElementLimit` row to the SERVER settings table in `src/main/asciidoc/reference/settings.adoc`, placed next to the related `ha.appendBufferSize` entry.
- Marked `_Since v26.7.1_` (the next release; engine is currently `26.7.1-SNAPSHOT`).

## Notes

- Not added to `how-to/operations/ha.adoc`, which intentionally lists only a curated subset of HA settings (it omits `appendBufferSize` too) and points to Server Settings for the complete list.

Upstream PR: ArcadeData/arcadedb#4753

🤖 Generated with [Claude Code](https://claude.com/claude-code)