### PR TITLE
docs(ha): the bolt:/grpc: server-list fields, and when a client routing address is withheld

### DIFF
--- a/src/main/asciidoc/how-to/connectivity/bolt.adoc
+++ b/src/main/asciidoc/how-to/connectivity/bolt.adoc
@@ -471,6 +471,8 @@ The routing table's time-to-live is controlled by `arcadedb.bolt.routing.ttl` (d
 [NOTE]
 ====
 For clusters where nodes expose the BOLT port on **different** ports, each node's client-reachable BOLT address must be declared using the object form of `arcadedb.ha.serverList` (`host:{raft:..,http:..,bolt:..}`). When omitted, each peer's BOLT address is derived from its Raft host plus this node's BOLT port, which is correct only for homogeneous deployments (for example, a Kubernetes StatefulSet).
+
+When the derived addresses cannot tell two peers apart - nodes that share a host and differ only by port - no routing table is advertised at all, and the node answers ROUTE with itself as READ and ROUTE only, exactly as it does mid-election. Declaring `bolt` is what restores a WRITE entry. See the HA guide, _Client Routing Ports_. _(Since v26.9.1)_
 ====
 
 ===== Current Limitations

--- a/src/main/asciidoc/how-to/operations/ha.adoc
+++ b/src/main/asciidoc/how-to/operations/ha.adoc
@@ -54,8 +54,12 @@ Fields are unordered and all optional, with these defaults:
 |`raft` |Raft gRPC consensus port. Defaults to `arcadedb.ha.raftPort` (`2434`) when omitted.
 |`http` |HTTP port, used by replicas to forward non-idempotent requests to the leader. Omit if not needed.
 |`https` |HTTPS port, used for *encrypted* peer-to-peer transfers (e.g. snapshot download) when `arcadedb.ssl.enabled=true`. See <<ha-ssl,TLS/SSL>>.
+|`bolt` |Client-reachable BOLT port, advertised in the BOLT routing table so `neo4j://` drivers find the leader and the followers. See <<ha-client-routing-ports,Client Routing Ports>>.
+|`grpc` |Client-reachable gRPC port, advertised when a gRPC call refused on a follower names the leader to retry against. See <<ha-client-routing-ports,Client Routing Ports>>. _(Since v26.9.1)_
 |`priority` |Leader-election preference (integer, default `0`). The node with the highest priority is preferred as leader.
 |===
++
+NOTE: `bolt` and `grpc` have no positional equivalent - an entry declaring either must use the object form.
 
 *Positional form*::
 A colon-separated entry where each field is identified by position:
@@ -79,6 +83,26 @@ The following two entries are equivalent:
 # Positional form
 -Darcadedb.ha.serverList=db1:2434:2480:10:2490
 ----
+
+[[ha-client-routing-ports]]
+===== Client Routing Ports (`bolt`, `grpc`)
+
+A client protocol's routing view tells a driver which node to send writes to and which nodes it may read from, so it deals in the ports *clients* dial - never the Raft port the cluster uses to talk to itself, and not necessarily the HTTP port either.
+
+*Declare `bolt` and `grpc` whenever your nodes do not all listen on the same port for that protocol.*
+With the field omitted, a peer's address for that protocol is derived as _that peer's host_ plus _this node's own port_. That is correct only for a homogeneous deployment where every node listens on the same port - a Kubernetes StatefulSet, for example - and a one-time WARNING per protocol is logged whenever the fallback is used.
+
+[source,shell]
+----
+# Three nodes on one host: same host, different ports - what the fallback cannot express
+-Darcadedb.ha.serverList=n0@localhost:{raft:2434,http:2480,bolt:7687,grpc:50051},n1@localhost:{raft:2435,http:2481,bolt:7688,grpc:50052},n2@localhost:{raft:2436,http:2482,bolt:7689,grpc:50053}
+----
+
+On a cluster like that one, leaving the ports undeclared makes every peer derive to the *same* address - and an address two peers both claim identifies neither of them, since two listening sockets cannot share one `host:port`.
+Rather than advertise a leader address that is really the address of the node answering (which would send a self-redirecting client straight back to the node that just refused it), ArcadeDB advertises nothing for that protocol: BOLT then offers this node as READ and ROUTE but never as writer, and a refused gRPC call falls back to naming the leader's HTTP address.
+A WARNING naming the field to declare is logged once per protocol. _(Since v26.9.1)_
+
+TIP: A declared address always wins over a derived one. Declaring the ports of the nodes that differ is enough; the rest may keep deriving.
 
 [[ha-named-peers]]
 ===== Named Peers (from v26.5.1)

--- a/src/main/asciidoc/reference/settings.adoc
+++ b/src/main/asciidoc/reference/settings.adoc
@@ -305,13 +305,13 @@ The gRPC server is implemented by the `GrpcServerPlugin`, which is bundled in th
 -Darcadedb.server.plugins=gRPC:com.arcadedb.server.grpc.GrpcServerPlugin
 ----
 
-Once enabled, the server listens on port `50051` by default. The settings below are read by the plugin itself and are *not* part of the registered server settings above, so they only take effect as JVM system properties (`-Darcadedb.grpc.*`); they are not resolved from environment variables. The `server.plugins` setting itself is a standard server setting and can be supplied either way.
+Once enabled, the server listens on port `50051` by default. Except for `grpc.port`, the settings below are read by the plugin itself and are *not* part of the registered server settings above, so they only take effect as JVM system properties (`-Darcadedb.grpc.*`); they are not resolved from environment variables. The `server.plugins` setting itself is a standard server setting and can be supplied either way.
 
 [%header,cols="25%,50%,10%,15%",stripes=even]
 |===
 |Name|Description|Type|Default Value
 |`grpc.enabled`|Start the gRPC server when the plugin is registered. Set to `false` to keep the plugin loaded but the listener stopped|Boolean|true
-|`grpc.port`|Port for the standard gRPC server|Integer|50051
+|`grpc.port`|Port for the standard gRPC server. A registered server setting since v26.9.1 (so it is also resolved from environment variables and listed in the settings API), because HA reads it to advertise a peer's gRPC endpoint - see the `grpc` field of `arcadedb.ha.serverList`|Integer|50051
 |`grpc.host`|Host/interface to bind to|String|0.0.0.0
 |`grpc.mode`|Server mode: `standard`, `xds`, or `both`|String|standard
 |`grpc.xds.port`|Port for the xDS server (used when `grpc.mode` is `xds` or `both`)|Integer|50052


### PR DESCRIPTION
Companion to ArcadeData/arcadedb#6187 (issue ArcadeData/arcadedb#6183, item 3).

The object form of `arcadedb.ha.serverList` gained `bolt:` when #5002 added the BOLT routing table and `grpc:` when #6091 made a gRPC refusal name a dialable leader. Only `bolt:` had ever been mentioned in the docs, and only in passing on the BOLT page; the server-list reference itself listed neither.

- **`how-to/operations/ha.adoc`**: `bolt` and `grpc` rows in the object-form field table, a note that neither has a positional equivalent, and a new **Client Routing Ports** section carrying the sentence that matters operationally - *declare them whenever your nodes do not all listen on the same port for that protocol*, because the fallback derives a peer's address from this node's own port. The section also documents what ArcadeData/arcadedb#6183 changed: when two peers derive to the same address, neither is advertised (two listening sockets cannot own one `host:port`), and nothing is advertised at all when the leader is one of them.
- **`how-to/connectivity/bolt.adoc`**: the existing heterogeneous-ports note gains what a driver now sees in that case - ROUTE answers with this node as READ and ROUTE only, exactly as mid-election, and declaring `bolt` is what restores a WRITE entry.
- **`reference/settings.adoc`**: `grpc.port` is a registered server setting since v26.9.1, so unlike the other `grpc.*` keys it is resolved from environment variables and appears in the settings API; the paragraph claiming otherwise for all of them is corrected.