### PR TITLE
docs(http,ha): the retries default, the third verify outcome, and a withheld peer endpoint

### DIFF
--- a/src/main/asciidoc/how-to/connectivity/bolt.adoc
+++ b/src/main/asciidoc/how-to/connectivity/bolt.adoc
@@ -471,6 +471,8 @@ The routing table's time-to-live is controlled by `arcadedb.bolt.routing.ttl` (d
 [NOTE]
 ====
 For clusters where nodes expose the BOLT port on **different** ports, each node's client-reachable BOLT address must be declared using the object form of `arcadedb.ha.serverList` (`host:{raft:..,http:..,bolt:..}`). When omitted, each peer's BOLT address is derived from its Raft host plus this node's BOLT port, which is correct only for homogeneous deployments (for example, a Kubernetes StatefulSet).
+
+When the derived addresses cannot tell two peers apart - nodes that share a host and differ only by port - no routing table is advertised at all, and the node answers ROUTE with itself as READ and ROUTE only, exactly as it does mid-election. Declaring `bolt` is what restores a WRITE entry. See the HA guide, _Client Routing Ports_. _(Since v26.9.1)_
 ====
 
 ===== Current Limitations

--- a/src/main/asciidoc/how-to/operations/ha.adoc
+++ b/src/main/asciidoc/how-to/operations/ha.adoc
@@ -104,6 +104,20 @@ A WARNING naming the field to declare is logged once per protocol. _(Since v26.9
 
 TIP: A declared address always wins over a derived one. Declaring the ports of the nodes that differ is enough; the rest may keep deriving.
 
+[[ha-peer-endpoint-ambiguity]]
+===== Peer-to-Peer Endpoints (`http`, `https`)
+
+The same derive-from-this-node's-port fallback applies to the endpoints the *nodes* use to reach each other: a follower downloading a snapshot from the leader, a cluster verify comparing checksums with a peer, and the database presence matrix (`GET /api/v1/cluster?presence=true`).
+When two peers resolve to one `host:port`, that address identifies at most one of them and nothing can say which, so ArcadeDB *withholds* it rather than guessing: the operation is refused and reported as refused - a peer comes back `ERROR` / "not verified" from a verify, and unreachable from a presence matrix - instead of quietly answering for the wrong node. _(Since v26.9.1)_
+
+The refusal is visible in three places:
+
+* a one-time WARNING per protocol, naming the peers that could not be told apart, the address they share, and the field to declare;
+* `httpAddressAmbiguous: true` next to that peer's `httpAddress` in `GET /api/v1/cluster`, and a warning line on the node's card in the Studio Cluster dashboard;
+* the error text of whichever operation was refused.
+
+NOTE: `http` and `https` are checked independently, because they are read from independent fields with independent fallbacks. A cluster that declares distinct `http` ports and omits the `https` ones passes the HTTP check with every peer's HTTPS endpoint still collapsed onto this node's own; the encrypted transfer then falls back to the (guarded) plain-HTTP endpoint.
+
 [[ha-named-peers]]
 ===== Named Peers (from v26.5.1)
 
@@ -476,7 +490,7 @@ All endpoints require authentication as the `root` user.
 
 |POST
 |`/api/v1/cluster/verify/{database}`
-|Compare component file checksums for the given database across all peers. Useful to confirm that all nodes have converged.
+|Compare component file checksums for the given database across all peers. Useful to confirm that all nodes have converged. See <<ha-verify-outcome,Verify Outcomes>> for the values `overallStatus` can take.
 
 |GET
 |`/api/v1/ha/snapshot/{database}`
@@ -502,6 +516,24 @@ $ curl -u root:<password> \
        -H 'Content-Type: application/json' \
        -d '{"peerId":"10.0.0.4_2434","address":"10.0.0.4:2434:2480","name":"frankfurt"}'
 ----
+
+[[ha-verify-outcome]]
+===== Verify Outcomes
+
+`POST /api/v1/cluster/verify/{database}` reports one `status` per peer and rolls them up into a single `result.overallStatus`:
+
+[cols="1,4",options="header"]
+|===
+|`overallStatus` |Meaning
+|`ALL_CONSISTENT` |Every peer was contacted and every peer's checksums match this node's.
+|`INCONSISTENCY_DETECTED` |At least one peer was contacted and its checksums differ - a divergence somebody has actually observed.
+|`VERIFICATION_INCOMPLETE` |No divergence was observed, but at least one peer could not be verified: it was unreachable, or its address does not identify it (see <<ha-peer-endpoint-ambiguity,Peer-to-Peer Endpoints>>). Such a peer is reported with `status: ERROR` and an `error` naming what to fix. _(Since v26.9.1)_
+|===
+
+`ALL_CONSISTENT` therefore means what it says: it is not reachable while any peer is unverified.
+An unverified peer is deliberately *not* rolled up as an observed divergence, which would send an operator hunting for something nobody saw.
+
+IMPORTANT: Alerting that keys on `overallStatus != "ALL_CONSISTENT"` is unaffected by the third value. Alerting that keys on `overallStatus == "INCONSISTENCY_DETECTED"` must add `VERIFICATION_INCOMPLETE` to keep catching an unreachable or unidentifiable node.
 
 ===== Studio Cluster Dashboard (from v26.4.1)
 

--- a/src/main/asciidoc/how-to/operations/ha.adoc
+++ b/src/main/asciidoc/how-to/operations/ha.adoc
@@ -54,8 +54,12 @@ Fields are unordered and all optional, with these defaults:
 |`raft` |Raft gRPC consensus port. Defaults to `arcadedb.ha.raftPort` (`2434`) when omitted.
 |`http` |HTTP port, used by replicas to forward non-idempotent requests to the leader. Omit if not needed.
 |`https` |HTTPS port, used for *encrypted* peer-to-peer transfers (e.g. snapshot download) when `arcadedb.ssl.enabled=true`. See <<ha-ssl,TLS/SSL>>.
+|`bolt` |Client-reachable BOLT port, advertised in the BOLT routing table so `neo4j://` drivers find the leader and the followers. See <<ha-client-routing-ports,Client Routing Ports>>.
+|`grpc` |Client-reachable gRPC port, advertised when a gRPC call refused on a follower names the leader to retry against. See <<ha-client-routing-ports,Client Routing Ports>>. _(Since v26.9.1)_
 |`priority` |Leader-election preference (integer, default `0`). The node with the highest priority is preferred as leader.
 |===
++
+NOTE: `bolt` and `grpc` have no positional equivalent - an entry declaring either must use the object form.
 
 *Positional form*::
 A colon-separated entry where each field is identified by position:
@@ -79,6 +83,26 @@ The following two entries are equivalent:
 # Positional form
 -Darcadedb.ha.serverList=db1:2434:2480:10:2490
 ----
+
+[[ha-client-routing-ports]]
+===== Client Routing Ports (`bolt`, `grpc`)
+
+A client protocol's routing view tells a driver which node to send writes to and which nodes it may read from, so it deals in the ports *clients* dial - never the Raft port the cluster uses to talk to itself, and not necessarily the HTTP port either.
+
+*Declare `bolt` and `grpc` whenever your nodes do not all listen on the same port for that protocol.*
+With the field omitted, a peer's address for that protocol is derived as _that peer's host_ plus _this node's own port_. That is correct only for a homogeneous deployment where every node listens on the same port - a Kubernetes StatefulSet, for example - and a one-time WARNING per protocol is logged whenever the fallback is used.
+
+[source,shell]
+----
+# Three nodes on one host: same host, different ports - what the fallback cannot express
+-Darcadedb.ha.serverList=n0@localhost:{raft:2434,http:2480,bolt:7687,grpc:50051},n1@localhost:{raft:2435,http:2481,bolt:7688,grpc:50052},n2@localhost:{raft:2436,http:2482,bolt:7689,grpc:50053}
+----
+
+On a cluster like that one, leaving the ports undeclared makes every peer derive to the *same* address - and an address two peers both claim identifies neither of them, since two listening sockets cannot share one `host:port`.
+Rather than advertise a leader address that is really the address of the node answering (which would send a self-redirecting client straight back to the node that just refused it), ArcadeDB advertises nothing for that protocol: BOLT then offers this node as READ and ROUTE but never as writer, and a refused gRPC call falls back to naming the leader's HTTP address.
+A WARNING naming the field to declare is logged once per protocol. _(Since v26.9.1)_
+
+TIP: A declared address always wins over a derived one. Declaring the ports of the nodes that differ is enough; the rest may keep deriving.
 
 [[ha-named-peers]]
 ===== Named Peers (from v26.5.1)

--- a/src/main/asciidoc/reference/http-api/http.adoc
+++ b/src/main/asciidoc/reference/http-api/http.adoc
@@ -957,7 +957,14 @@ The payload, as a JSON, accepts the following parameters:
 The completion of the command is noted in the log, yet no results of the command can be returned.
 - `limit` (optional) is the maximum number of results to return
 - `params` (optional), is the map of parameters to pass to the query engine, where parameters are prefixed with a colon `:`. Parameter values may include the typed-marker objects described in <<vector-http-typed-markers,Typed parameter markers>> to send `byte[]` -- e.g. INT8-encoded vectors -- without a float32 round trip.
-- `retries` (optional), is the number of times the command (transaction) is retried.
+- `retries` (optional), is the number of times the command (transaction) is retried. When omitted it follows the
+`arcadedb.txRetries` <<setting-database,database setting>> (3 by default), the same attempt count the embedded and
+the remote Java APIs take it from; up to v26.9.0 it was hard-coded to 1, so nothing was ever retried.
+Only a concurrent-modification conflict is retried (`NeedRetryException` and `DuplicatedKeyException`, the latter
+capped at a single retry), and always after a full rollback, so a retried attempt starts from committed state with
+nothing of the failed one surviving. Note the consequence for side effects *outside* the database: a SQL or
+JavaScript function that calls another system can now run more than once per request. Send `"retries": 1` to keep
+the previous single-attempt behavior for such a command.
 - `autoCommit` (optional) controls transaction behavior:
 ** `true`: Forces the command to execute within an atomic transaction that auto-commits on success
 ** `false`: Disables automatic transaction wrapping (command executes directly without transaction)

--- a/src/main/asciidoc/reference/settings.adoc
+++ b/src/main/asciidoc/reference/settings.adoc
@@ -305,13 +305,13 @@ The gRPC server is implemented by the `GrpcServerPlugin`, which is bundled in th
 -Darcadedb.server.plugins=gRPC:com.arcadedb.server.grpc.GrpcServerPlugin
 ----
 
-Once enabled, the server listens on port `50051` by default. The settings below are read by the plugin itself and are *not* part of the registered server settings above, so they only take effect as JVM system properties (`-Darcadedb.grpc.*`); they are not resolved from environment variables. The `server.plugins` setting itself is a standard server setting and can be supplied either way.
+Once enabled, the server listens on port `50051` by default. Except for `grpc.port`, the settings below are read by the plugin itself and are *not* part of the registered server settings above, so they only take effect as JVM system properties (`-Darcadedb.grpc.*`); they are not resolved from environment variables. The `server.plugins` setting itself is a standard server setting and can be supplied either way.
 
 [%header,cols="25%,50%,10%,15%",stripes=even]
 |===
 |Name|Description|Type|Default Value
 |`grpc.enabled`|Start the gRPC server when the plugin is registered. Set to `false` to keep the plugin loaded but the listener stopped|Boolean|true
-|`grpc.port`|Port for the standard gRPC server|Integer|50051
+|`grpc.port`|Port for the standard gRPC server. A registered server setting since v26.9.1 (so it is also resolved from environment variables and listed in the settings API), because HA reads it to advertise a peer's gRPC endpoint - see the `grpc` field of `arcadedb.ha.serverList`|Integer|50051
 |`grpc.host`|Host/interface to bind to|String|0.0.0.0
 |`grpc.mode`|Server mode: `standard`, `xds`, or `both`|String|standard
 |`grpc.xds.port`|Port for the xDS server (used when `grpc.mode` is `xds` or `both`)|Integer|50052


### PR DESCRIPTION
Item 5 of ArcadeData/arcadedb#6267 - three API-visible changes the HTTP/HA reference had not caught up with. The engine-side PR is ArcadeData/arcadedb#6284.

**`retries`** on `POST /api/v1/command` (and every other auto-committing endpoint) now defaults to `arcadedb.txRetries` (3) instead of a hard-coded 1 - the same attempt count the embedded and remote Java APIs take. Documented with the caveat that actually matters to a user: only `NeedRetryException` / `DuplicatedKeyException` are retried, always after a full rollback, so nothing the failed attempt wrote survives - but the *command* runs again, so a SQL or JavaScript function with a side effect **outside** the database can now perform it more than once per request. `"retries": 1` keeps the old single-attempt behaviour.

**`overallStatus`** on `POST /api/v1/cluster/verify/{database}` has a third value, `VERIFICATION_INCOMPLETE` ("no divergence observed, but at least one peer could not be verified"). The endpoint had a one-line table cell and no description of its response at all, so this adds a "Verify Outcomes" section with all three values, why an unverified peer is deliberately not rolled up as an observed divergence, and the note for alerting: keying on `!= ALL_CONSISTENT` is unaffected, keying on `INCONSISTENCY_DETECTED` needs the new value added to keep catching an unreachable node.

**Peer-to-peer endpoints.** The existing "Client Routing Ports" section documents what happens when two peers derive to the same `bolt`/`grpc` address. The same thing happens to the `http`/`https` endpoints the *nodes* use to reach each other - a snapshot resync, a cluster verify, the presence matrix - and ArcadeData/arcadedb#6267 made that refusal visible instead of silent. The new section says what is withheld, the three places it now shows up (a one-time WARNING per protocol, `httpAddressAmbiguous` in `GET /api/v1/cluster` and on the Studio node card, and the error text of whichever operation was refused), and why `http` and `https` are checked independently.

Anchors added: `ha-peer-endpoint-ambiguity`, `ha-verify-outcome`. Both are referenced from within the same document; the `retries` paragraph links the existing `setting-database` anchor.